### PR TITLE
refactor: remove dead DeclaredContract/TypeConstraint infrastructure

### DIFF
--- a/src/trailmark/models/__init__.py
+++ b/src/trailmark/models/__init__.py
@@ -4,11 +4,9 @@ from trailmark.models.annotations import (
     Annotation,
     AnnotationKind,
     AssetValue,
-    DeclaredContract,
     EntrypointKind,
     EntrypointTag,
     TrustLevel,
-    TypeConstraint,
 )
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -29,7 +27,6 @@ __all__ = [
     "CodeEdge",
     "CodeGraph",
     "CodeUnit",
-    "DeclaredContract",
     "EdgeConfidence",
     "EdgeKind",
     "EntrypointKind",
@@ -38,6 +35,5 @@ __all__ = [
     "Parameter",
     "SourceLocation",
     "TrustLevel",
-    "TypeConstraint",
     "TypeRef",
 ]

--- a/src/trailmark/models/annotations.py
+++ b/src/trailmark/models/annotations.py
@@ -63,26 +63,3 @@ class EntrypointTag:
     trust_level: TrustLevel = TrustLevel.UNTRUSTED_EXTERNAL
     description: str | None = None
     asset_value: AssetValue = AssetValue.LOW
-
-
-@dataclass(frozen=True)
-class TypeConstraint:
-    """A constraint on a parameter's type or value domain."""
-
-    parameter_name: str
-    declared_type: str | None = None
-    value_constraint: str | None = None
-
-
-@dataclass(frozen=True)
-class DeclaredContract:
-    """What a function declares it accepts/returns.
-
-    Captured from type annotations, docstrings, assertions,
-    and explicit validation. Separate from effective input domain,
-    which is determined by graph reachability analysis.
-    """
-
-    parameter_types: tuple[TypeConstraint, ...] = ()
-    return_constraint: str | None = None
-    validation_notes: tuple[str, ...] = ()

--- a/src/trailmark/parsers/_common.py
+++ b/src/trailmark/parsers/_common.py
@@ -7,17 +7,12 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from trailmark.models.annotations import (
-    DeclaredContract,
-    TypeConstraint,
-)
 from trailmark.models.edges import CodeEdge, EdgeKind
 from trailmark.models.graph import CodeGraph
 from trailmark.models.nodes import (
     BranchInfo,
     CodeUnit,
     NodeKind,
-    Parameter,
     SourceLocation,
     TypeRef,
 )
@@ -205,28 +200,6 @@ def extract_call_name(node: Node) -> str:
 def compute_complexity(branches: list[BranchInfo]) -> int:
     """Compute cyclomatic complexity from collected branches."""
     return 1 + len(branches)
-
-
-def build_contract(
-    params: list[Parameter],
-    return_type: TypeRef | None,
-) -> DeclaredContract | None:
-    """Build a DeclaredContract from extracted parameter types."""
-    constraints: list[TypeConstraint] = []
-    for p in params:
-        if p.type_ref is not None:
-            constraints.append(
-                TypeConstraint(
-                    parameter_name=p.name,
-                    declared_type=p.type_ref.name,
-                )
-            )
-    if not constraints and return_type is None:
-        return None
-    return DeclaredContract(
-        parameter_types=tuple(constraints),
-        return_constraint=return_type.name if return_type else None,
-    )
 
 
 def add_module_node(

--- a/src/trailmark/parsers/c/parser.py
+++ b/src/trailmark/parsers/c/parser.py
@@ -19,7 +19,6 @@ from trailmark.models.nodes import (
 from trailmark.parsers._common import (
     add_contains_edge,
     add_module_node,
-    build_contract,
     collect_body_info,
     compute_complexity,
     make_location,
@@ -231,7 +230,6 @@ def _extract_function(
 
     complexity = compute_complexity(branches)
     location = make_location(node, file_path)
-    contract = build_contract(params, return_type)
     docstring = _extract_docstring(node)
 
     unit = CodeUnit(
@@ -248,9 +246,6 @@ def _extract_function(
     )
     graph.nodes[func_id] = unit
     add_contains_edge(graph, module_id, func_id)
-
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(calls, func_id, module_id, file_path, graph)
 

--- a/src/trailmark/parsers/cairo/parser.py
+++ b/src/trailmark/parsers/cairo/parser.py
@@ -19,7 +19,6 @@ from trailmark.models.nodes import (
 from trailmark.parsers._common import (
     add_contains_edge,
     add_module_node,
-    build_contract,
     collect_body_info,
     compute_complexity,
     make_location,
@@ -411,7 +410,6 @@ def _extract_function(
 
     branches, exception_types, calls = _collect_func_body(body, file_path)
     complexity = compute_complexity(branches)
-    contract = build_contract(params, return_type)
     docstring = _extract_docstring(node)
 
     unit = CodeUnit(
@@ -428,9 +426,6 @@ def _extract_function(
     )
     graph.nodes[func_id] = unit
     add_contains_edge(graph, owner, func_id)
-
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(calls, func_id, module_id, container_id, file_path, graph)
 

--- a/src/trailmark/parsers/cpp/parser.py
+++ b/src/trailmark/parsers/cpp/parser.py
@@ -19,7 +19,6 @@ from trailmark.models.nodes import (
 from trailmark.parsers._common import (
     add_contains_edge,
     add_module_node,
-    build_contract,
     collect_body_info,
     compute_complexity,
     make_location,
@@ -430,7 +429,6 @@ def _extract_function(
 
     complexity = compute_complexity(branches)
     location = make_location(node, file_path)
-    contract = build_contract(params, return_type)
     docstring = _extract_docstring(node)
 
     unit = CodeUnit(
@@ -447,9 +445,6 @@ def _extract_function(
     )
     graph.nodes[func_id] = unit
     add_contains_edge(graph, container_id, func_id)
-
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(
         calls,

--- a/src/trailmark/parsers/csharp/parser.py
+++ b/src/trailmark/parsers/csharp/parser.py
@@ -19,7 +19,6 @@ from trailmark.models.nodes import (
 from trailmark.parsers._common import (
     add_contains_edge,
     add_module_node,
-    build_contract,
     compute_complexity,
     make_location,
     module_id_from_path,
@@ -302,10 +301,6 @@ def _extract_function(
     )
     graph.nodes[func_id] = unit
     add_contains_edge(graph, container_id, func_id)
-
-    contract = build_contract(params, return_type)
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(
         calls,

--- a/src/trailmark/parsers/erlang/parser.py
+++ b/src/trailmark/parsers/erlang/parser.py
@@ -20,7 +20,6 @@ from trailmark.models.nodes import (
 from trailmark.parsers._common import (
     add_contains_edge,
     add_module_node,
-    build_contract,
     compute_complexity,
     make_location,
     module_id_from_path,
@@ -164,7 +163,6 @@ def _create_function_node(
     calls = _collect_calls(clause)
     exception_types = _collect_exceptions(calls)
     complexity = compute_complexity(branches)
-    contract = build_contract(params, return_type)
     docstring = _extract_docstring(clause)
 
     unit = CodeUnit(
@@ -182,9 +180,6 @@ def _create_function_node(
     graph.nodes[func_id] = unit
     add_contains_edge(graph, module_id, func_id)
     seen_funcs[name] = func_id
-
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(calls, func_id, module_id, file_path, graph)
 

--- a/src/trailmark/parsers/go/parser.py
+++ b/src/trailmark/parsers/go/parser.py
@@ -19,7 +19,6 @@ from trailmark.models.nodes import (
 from trailmark.parsers._common import (
     add_contains_edge,
     add_module_node,
-    build_contract,
     collect_body_info,
     compute_complexity,
     make_location,
@@ -196,7 +195,6 @@ def _extract_function(
         file_path,
     )
     complexity = compute_complexity(branches)
-    contract = build_contract(params, return_type)
     docstring = _extract_docstring(node)
 
     unit = CodeUnit(
@@ -213,9 +211,6 @@ def _extract_function(
     )
     graph.nodes[func_id] = unit
     add_contains_edge(graph, module_id, func_id)
-
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(
         calls,
@@ -252,7 +247,6 @@ def _extract_method(
         file_path,
     )
     complexity = compute_complexity(branches)
-    contract = build_contract(params, return_type)
     docstring = _extract_docstring(node)
 
     unit = CodeUnit(
@@ -269,9 +263,6 @@ def _extract_method(
     )
     graph.nodes[method_id] = unit
     add_contains_edge(graph, type_id, method_id)
-
-    if contract is not None:
-        graph.annotations.setdefault(method_id, [])
 
     _add_call_edges(
         calls,

--- a/src/trailmark/parsers/haskell/parser.py
+++ b/src/trailmark/parsers/haskell/parser.py
@@ -20,7 +20,6 @@ from trailmark.models.nodes import (
 from trailmark.parsers._common import (
     add_contains_edge,
     add_module_node,
-    build_contract,
     compute_complexity,
     make_location,
     module_id_from_path,
@@ -339,7 +338,6 @@ def _create_function_node(
     branches = _collect_branches(node, file_path)
     calls = _collect_calls(node)
     complexity = compute_complexity(branches)
-    contract = build_contract(params, return_type)
     docstring = _extract_docstring(node)
 
     unit = CodeUnit(
@@ -357,9 +355,6 @@ def _create_function_node(
     graph.nodes[func_id] = unit
     add_contains_edge(graph, owner, func_id)
     seen_funcs[name] = func_id
-
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(calls, func_id, module_id, container_id, file_path, graph)
 

--- a/src/trailmark/parsers/java/parser.py
+++ b/src/trailmark/parsers/java/parser.py
@@ -19,7 +19,6 @@ from trailmark.models.nodes import (
 from trailmark.parsers._common import (
     add_contains_edge,
     add_module_node,
-    build_contract,
     compute_complexity,
     make_location,
     module_id_from_path,
@@ -268,10 +267,6 @@ def _extract_function(
     )
     graph.nodes[func_id] = unit
     add_contains_edge(graph, container_id, func_id)
-
-    contract = build_contract(params, return_type)
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(
         calls,

--- a/src/trailmark/parsers/javascript/parser.py
+++ b/src/trailmark/parsers/javascript/parser.py
@@ -19,7 +19,6 @@ from trailmark.models.nodes import (
 from trailmark.parsers._common import (
     add_contains_edge,
     add_module_node,
-    build_contract,
     collect_body_info,
     compute_complexity,
     make_location,
@@ -233,7 +232,6 @@ def _extract_function_expr(
 
     complexity = compute_complexity(branches)
     location = make_location(func_node, file_path)
-    contract = build_contract(params, None)
 
     unit = CodeUnit(
         id=func_id,
@@ -248,9 +246,6 @@ def _extract_function_expr(
     )
     graph.nodes[func_id] = unit
     add_contains_edge(graph, module_id, func_id)
-
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(
         calls,
@@ -443,7 +438,6 @@ def _extract_function(
 
     complexity = compute_complexity(branches)
     location = make_location(node, file_path)
-    contract = build_contract(params, None)
 
     unit = CodeUnit(
         id=func_id,
@@ -458,9 +452,6 @@ def _extract_function(
     )
     graph.nodes[func_id] = unit
     add_contains_edge(graph, container_id, func_id)
-
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(
         calls,

--- a/src/trailmark/parsers/php/parser.py
+++ b/src/trailmark/parsers/php/parser.py
@@ -19,7 +19,6 @@ from trailmark.models.nodes import (
 from trailmark.parsers._common import (
     add_contains_edge,
     add_module_node,
-    build_contract,
     compute_complexity,
     make_location,
     module_id_from_path,
@@ -294,7 +293,6 @@ def _extract_function(
 
     complexity = compute_complexity(branches)
     location = make_location(node, file_path)
-    contract = build_contract(params, return_type)
 
     unit = CodeUnit(
         id=func_id,
@@ -310,9 +308,6 @@ def _extract_function(
     )
     graph.nodes[func_id] = unit
     add_contains_edge(graph, container_id, func_id)
-
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(
         calls,

--- a/src/trailmark/parsers/python/parser.py
+++ b/src/trailmark/parsers/python/parser.py
@@ -19,7 +19,6 @@ from trailmark.models.nodes import (
 from trailmark.parsers._common import (
     add_contains_edge,
     add_module_node,
-    build_contract,
     collect_body_info,
     compute_complexity,
     make_location,
@@ -224,7 +223,6 @@ def _extract_function(
     complexity = compute_complexity(branches)
 
     location = make_location(node, file_path)
-    contract = build_contract(params, return_type)
 
     unit = CodeUnit(
         id=func_id,
@@ -241,9 +239,6 @@ def _extract_function(
     graph.nodes[func_id] = unit
 
     add_contains_edge(graph, container_id, func_id)
-
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     for call_name, call_node in calls:
         target_id = _resolve_call_target(

--- a/src/trailmark/parsers/rust/parser.py
+++ b/src/trailmark/parsers/rust/parser.py
@@ -19,7 +19,6 @@ from trailmark.models.nodes import (
 from trailmark.parsers._common import (
     add_contains_edge,
     add_module_node,
-    build_contract,
     collect_body_info,
     compute_complexity,
     make_location,
@@ -299,7 +298,6 @@ def _extract_function(
         file_path,
     )
     complexity = compute_complexity(branches)
-    contract = build_contract(params, return_type)
     docstring = _extract_docstring(node)
 
     unit = CodeUnit(
@@ -316,9 +314,6 @@ def _extract_function(
     )
     graph.nodes[func_id] = unit
     add_contains_edge(graph, owner, func_id)
-
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(
         calls,

--- a/src/trailmark/parsers/solidity/parser.py
+++ b/src/trailmark/parsers/solidity/parser.py
@@ -19,7 +19,6 @@ from trailmark.models.nodes import (
 from trailmark.parsers._common import (
     add_contains_edge,
     add_module_node,
-    build_contract,
     collect_body_info,
     compute_complexity,
     make_location,
@@ -267,7 +266,6 @@ def _extract_function(
 
     branches, exception_types, calls = _collect_func_body(body, file_path)
     complexity = compute_complexity(branches)
-    contract = build_contract(params, return_type)
     docstring = _extract_docstring(node)
 
     unit = CodeUnit(
@@ -284,9 +282,6 @@ def _extract_function(
     )
     graph.nodes[func_id] = unit
     add_contains_edge(graph, owner, func_id)
-
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(calls, func_id, module_id, contract_id, file_path, graph)
 

--- a/src/trailmark/parsers/typescript/parser.py
+++ b/src/trailmark/parsers/typescript/parser.py
@@ -19,7 +19,6 @@ from trailmark.models.nodes import (
 from trailmark.parsers._common import (
     add_contains_edge,
     add_module_node,
-    build_contract,
     collect_body_info,
     compute_complexity,
     make_location,
@@ -238,7 +237,6 @@ def _extract_function_expr(
 
     complexity = compute_complexity(branches)
     location = make_location(func_node, file_path)
-    contract = build_contract(params, return_type)
 
     unit = CodeUnit(
         id=func_id,
@@ -254,9 +252,6 @@ def _extract_function_expr(
     )
     graph.nodes[func_id] = unit
     add_contains_edge(graph, module_id, func_id)
-
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(
         calls,
@@ -567,7 +562,6 @@ def _extract_method(
 
     complexity = compute_complexity(branches)
     location = make_location(node, file_path)
-    contract = build_contract(params, return_type)
 
     unit = CodeUnit(
         id=method_id,
@@ -583,9 +577,6 @@ def _extract_method(
     )
     graph.nodes[method_id] = unit
     add_contains_edge(graph, class_id, method_id)
-
-    if contract is not None:
-        graph.annotations.setdefault(method_id, [])
 
     _add_call_edges(
         calls,
@@ -641,7 +632,6 @@ def _extract_function(
 
     complexity = compute_complexity(branches)
     location = make_location(node, file_path)
-    contract = build_contract(params, return_type)
 
     unit = CodeUnit(
         id=func_id,
@@ -657,9 +647,6 @@ def _extract_function(
     )
     graph.nodes[func_id] = unit
     add_contains_edge(graph, container_id, func_id)
-
-    if contract is not None:
-        graph.annotations.setdefault(func_id, [])
 
     _add_call_edges(
         calls,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,7 +10,6 @@ from trailmark.models import (
     CodeEdge,
     CodeGraph,
     CodeUnit,
-    DeclaredContract,
     EdgeConfidence,
     EdgeKind,
     EntrypointKind,
@@ -19,7 +18,6 @@ from trailmark.models import (
     Parameter,
     SourceLocation,
     TrustLevel,
-    TypeConstraint,
     TypeRef,
 )
 
@@ -160,19 +158,6 @@ class TestAnnotations:
         tag = EntrypointTag(kind=EntrypointKind.USER_INPUT)
         assert tag.trust_level == TrustLevel.UNTRUSTED_EXTERNAL
         assert tag.asset_value == AssetValue.LOW
-
-    def test_declared_contract(self) -> None:
-        c = DeclaredContract(
-            parameter_types=(
-                TypeConstraint(
-                    parameter_name="x",
-                    declared_type="int",
-                ),
-            ),
-            return_constraint="str",
-        )
-        assert len(c.parameter_types) == 1
-        assert c.return_constraint == "str"
 
 
 class TestCodeGraph:

--- a/tests/test_parser_edge_cases.py
+++ b/tests/test_parser_edge_cases.py
@@ -266,32 +266,27 @@ class TestLocationFields:
         assert branch_loc.start_col is not None
 
 
-class TestContractBuilding:
-    def test_contract_with_return_only(self) -> None:
+class TestTypeCapture:
+    def test_return_type_captured(self) -> None:
         code = "def f(x) -> int:\n    return x\n"
         _, graph = _parse_code(code)
         func = next(n for n in graph.nodes.values() if n.name == "f")
         assert func.return_type is not None
         assert func.return_type.name == "int"
 
-    def test_contract_with_typed_params(self) -> None:
-        """Typed params should create annotations entry."""
+    def test_typed_parameters_captured(self) -> None:
         code = "def f(x: int, y: str) -> bool:\n    return True\n"
         _, graph = _parse_code(code)
         func = next(n for n in graph.nodes.values() if n.name == "f")
         assert func.return_type is not None
         assert func.return_type.name == "bool"
         assert len(func.parameters) == 2
-        # Contract creates an annotations entry
-        assert func.id in graph.annotations
 
-    def test_no_contract_for_untyped(self) -> None:
-        """Functions with no types should not get annotation."""
+    def test_untyped_function_has_no_return_type(self) -> None:
         code = "def f(x):\n    return x\n"
         _, graph = _parse_code(code)
         func = next(n for n in graph.nodes.values() if n.name == "f")
         assert func.return_type is None
-        assert func.id not in graph.annotations
 
 
 class TestGenericReturnType:


### PR DESCRIPTION
DeclaredContract and TypeConstraint were defined in models/annotations.py and exported from models/__init__.py, but the data they carried was pure redundancy with existing fields on CodeUnit:

- TypeConstraint(parameter_name, declared_type) == Parameter.name + Parameter.type_ref.name, both already on CodeUnit.
- DeclaredContract.return_constraint == CodeUnit.return_type.name.
- DeclaredContract.parameter_types iterates Parameter entries we already have via CodeUnit.parameters.

The 14 tree-sitter parsers all called build_contract(params, return_type) and bound the result to `contract`, then used it purely as a boolean in `if contract is not None: graph.annotations.setdefault(func_id, [])`. setdefault with an empty list adds nothing observable (preanalysis later prunes empty annotation lists), so the entire pipeline was dead.

Zero consumers in QueryEngine, zero CLI surface, zero skill references. Decision: kill it. If type-level queries become necessary later, they can read Parameter.type_ref and CodeUnit.return_type directly, or a dedicated QueryEngine method can be added then with real semantics.

Removed:
- models.DeclaredContract, models.TypeConstraint (deleted from annotations.py and the models/__init__.py exports/__all__).
- _common.build_contract (helper and its imports).
- 14 per-parser `contract = build_contract(...)` calls and the dead `if contract is not None: ... setdefault(...)` blocks.
- The TestContractBuilding test class; the useful sub-assertions (return_type capture, parameter count) moved to TestTypeCapture.

842 tests pass, lint/format/type check clean.