### PR TITLE
feat(parsers): add Kotlin language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A language-specific parser walks the directory, parses each file into a tree-sit
 | Miden Assembly | `.masm` | procedures, entrypoints, constants, invocations |
 | Swift | `.swift` | functions, classes, structs, enums, protocols, extensions |
 | Objective-C | `.m`, `.mm`, `.h` | C functions, classes, methods (selector-based naming) |
+| Kotlin | `.kt`, `.kts` | functions, classes, interfaces, data classes, objects, methods |
 
 ```mermaid
 flowchart TD
@@ -293,6 +294,7 @@ Framework coverage:
 | Erlang | functions listed in `-export([...])` |
 | Swift | `@main` app attribute |
 | Objective-C | `UIApplicationDelegate` lifecycle selectors (e.g. `application:openURL:options:`) |
+| Kotlin | Spring MVC / WebFlux annotations (shared with Java), Android component lifecycle methods (`onCreate`, `onReceive`, `onBind`, ...) |
 
 For anything the heuristics miss, declare entrypoints explicitly in `.trailmark/entrypoints.toml` at the project root:
 

--- a/src/trailmark/analysis/entrypoints.py
+++ b/src/trailmark/analysis/entrypoints.py
@@ -168,6 +168,27 @@ _OBJC_APP_DELEGATE_SELECTORS = frozenset(
     }
 )
 
+# Kotlin — Ktor routing DSL: `get("/path") { ... }`, `post`, etc.
+# These appear as call expressions inside a `routing { ... }` block. The
+# file-level heuristic matches the verb calls; without block-level context
+# we can't distinguish Ktor routes from bare HTTP client calls, so Ktor
+# detection is currently disabled in favor of the override file.
+
+# Kotlin — Android Activity lifecycle overrides. Names and signatures
+# are stable across Android SDK versions.
+_KOTLIN_ANDROID_LIFECYCLE_METHODS = frozenset(
+    {
+        "onCreate",
+        "onStart",
+        "onResume",
+        "onNewIntent",
+        "onActivityResult",
+        "onReceive",  # BroadcastReceiver
+        "onBind",  # Service
+        "onHandleIntent",  # IntentService
+    }
+)
+
 _KIND_BY_NAME = {k.value: k for k in EntrypointKind}
 _TRUST_BY_NAME = {t.value: t for t in TrustLevel}
 _ASSET_BY_NAME = {a.value: a for a in AssetValue}
@@ -260,6 +281,8 @@ def _detect_for_unit(
         return _detect_swift(cache, unit, path)
     if path.endswith((".m", ".mm", ".h")):
         return _detect_objc(unit)
+    if path.endswith((".kt", ".kts")):
+        return _detect_kotlin(cache, unit, path)
     return None
 
 
@@ -649,6 +672,41 @@ def _detect_swift(
             # Without call-graph resolution this is coarse — Vapor-handler
             # detection is best done via the override file for now.
             break
+    return None
+
+
+def _detect_kotlin(
+    cache: _SourceCache,
+    unit: CodeUnit,
+    path: str,
+) -> EntrypointTag | None:
+    """Detect Kotlin entrypoints.
+
+    Layers tried in order:
+    1. Spring MVC / WebFlux annotations (``@GetMapping``, ``@PostMapping``,
+       etc.) — shared with the Java detector because the annotations are
+       identical across the two languages.
+    2. Android Activity / Service / BroadcastReceiver lifecycle method
+       names. These are attacker-reachable when the component is exported
+       (``android:exported="true"`` in the manifest) — we over-detect
+       here and let the override file tighten when appropriate.
+    """
+    decorators = cache.decorators_above(path, unit.location.start_line)
+    for line in decorators:
+        if _JAVA_SPRING_HANDLER.match(line):
+            return EntrypointTag(
+                kind=EntrypointKind.API,
+                trust_level=TrustLevel.UNTRUSTED_EXTERNAL,
+                description="Spring MVC/WebFlux handler (Kotlin)",
+                asset_value=AssetValue.HIGH,
+            )
+    if unit.name in _KOTLIN_ANDROID_LIFECYCLE_METHODS:
+        return EntrypointTag(
+            kind=EntrypointKind.API,
+            trust_level=TrustLevel.UNTRUSTED_EXTERNAL,
+            description="Android component lifecycle method",
+            asset_value=AssetValue.HIGH,
+        )
     return None
 
 

--- a/src/trailmark/parsers/kotlin/__init__.py
+++ b/src/trailmark/parsers/kotlin/__init__.py
@@ -1,0 +1,5 @@
+"""Kotlin language parser for Trailmark."""
+
+from trailmark.parsers.kotlin.parser import KotlinParser
+
+__all__ = ["KotlinParser"]

--- a/src/trailmark/parsers/kotlin/parser.py
+++ b/src/trailmark/parsers/kotlin/parser.py
@@ -1,0 +1,321 @@
+"""Kotlin language parser using tree-sitter.
+
+Targets Kotlin source used in Android apps, Spring backends, and Ktor
+services. Extracts:
+
+- Top-level functions (``fun main()``, ``suspend fun fetch(...)``).
+- Classes, interfaces, data classes, objects, enum classes.
+- Methods declared inside ``class_body``.
+- Parameters (``function_value_parameters`` → ``parameter``).
+- Return types from the type node that follows ``:`` on the signature.
+- Imports (``import_header``).
+
+Known gap (deferred, parallel to Swift): ``throw`` statements are wrapped
+in ``jump_expression`` nodes that also cover ``return``/``break``/
+``continue``. Capturing exception types requires a Kotlin-specific walk
+that filters by the leading ``throw`` token. Not implemented in this pass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tree_sitter import Node
+from tree_sitter_language_pack import get_parser
+
+from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
+from trailmark.models.graph import CodeGraph
+from trailmark.models.nodes import (
+    BranchInfo,
+    CodeUnit,
+    NodeKind,
+    Parameter,
+    TypeRef,
+)
+from trailmark.parsers._common import (
+    add_contains_edge,
+    add_module_node,
+    collect_body_info,
+    compute_complexity,
+    make_location,
+    module_id_from_path,
+    node_text,
+    parse_directory,
+)
+
+_EXTENSIONS = (".kt", ".kts")
+
+_BRANCH_NODE_TYPES = frozenset(
+    {
+        "if_expression",
+        "when_expression",
+        "when_entry",
+        "for_statement",
+        "while_statement",
+        "do_while_statement",
+        "catch_block",
+    }
+)
+
+# See parser docstring — throw capture deferred.
+_THROW_TYPES: frozenset[str] = frozenset()
+
+# Kotlin types that can appear at parameter/return position.
+_KOTLIN_TYPE_NODES = frozenset(
+    {
+        "user_type",
+        "type_identifier",
+        "nullable_type",
+        "function_type",
+        "parenthesized_type",
+    }
+)
+
+
+class KotlinParser:
+    """Parses Kotlin source files into CodeGraph using tree-sitter."""
+
+    @property
+    def language(self) -> str:
+        return "kotlin"
+
+    def __init__(self) -> None:
+        self._parser = get_parser("kotlin")
+
+    def parse_file(self, file_path: str) -> CodeGraph:
+        """Parse a single Kotlin file into a CodeGraph."""
+        source = Path(file_path).read_bytes()
+        tree = self._parser.parse(source)
+        graph = CodeGraph(language="kotlin", root_path=file_path)
+        module_id = module_id_from_path(file_path)
+        _visit_module(tree.root_node, file_path, module_id, graph)
+        return graph
+
+    def parse_directory(self, dir_path: str) -> CodeGraph:
+        """Parse all Kotlin source files under dir_path."""
+        return parse_directory(
+            self.parse_file,
+            "kotlin",
+            dir_path,
+            _EXTENSIONS,
+        )
+
+
+def _visit_module(
+    root: Node,
+    file_path: str,
+    module_id: str,
+    graph: CodeGraph,
+) -> None:
+    add_module_node(root, file_path, module_id, graph)
+    for child in root.children:
+        _visit_top_level_node(child, file_path, module_id, graph)
+
+
+def _visit_top_level_node(
+    child: Node,
+    file_path: str,
+    module_id: str,
+    graph: CodeGraph,
+) -> None:
+    if child.type == "function_declaration":
+        _extract_function(child, file_path, module_id, module_id, graph)
+    elif child.type == "class_declaration" or child.type == "object_declaration":
+        _extract_class_like(child, file_path, module_id, graph)
+    elif child.type == "import_list":
+        for header in child.children:
+            if header.type == "import_header":
+                _extract_import(header, graph)
+
+
+def _extract_class_like(
+    node: Node,
+    file_path: str,
+    module_id: str,
+    graph: CodeGraph,
+) -> None:
+    """Extract a Kotlin class / interface / data class / object."""
+    name_node = _first_child_by_type(node, "type_identifier")
+    if name_node is None:
+        return
+    class_name = node_text(name_node)
+    class_id = f"{module_id}:{class_name}"
+    kind = _kotlin_class_kind(node)
+    graph.nodes[class_id] = CodeUnit(
+        id=class_id,
+        name=class_name,
+        kind=kind,
+        location=make_location(node, file_path),
+    )
+    add_contains_edge(graph, module_id, class_id)
+
+    body = _first_child_by_type(node, "class_body")
+    if body is None:
+        body = _first_child_by_type(node, "enum_class_body")
+    if body is None:
+        return
+    for member in body.children:
+        if member.type == "function_declaration":
+            _extract_function(member, file_path, module_id, class_id, graph)
+
+
+def _kotlin_class_kind(node: Node) -> NodeKind:
+    """Determine whether a declaration is a class/interface/enum/object."""
+    has_data = False
+    has_enum = False
+    for child in node.children:
+        if child.type == "interface":
+            return NodeKind.INTERFACE
+        if child.type == "object":
+            return NodeKind.CLASS
+        if child.type == "modifiers":
+            for mod in child.children:
+                if mod.type == "class_modifier":
+                    modifier_text = node_text(mod)
+                    if modifier_text == "data":
+                        has_data = True
+                    elif modifier_text == "enum":
+                        has_enum = True
+    if has_enum:
+        return NodeKind.ENUM
+    if has_data:
+        # Data classes are still classes semantically; no separate kind.
+        return NodeKind.CLASS
+    return NodeKind.CLASS
+
+
+def _extract_function(
+    node: Node,
+    file_path: str,
+    module_id: str,
+    container_id: str,
+    graph: CodeGraph,
+) -> None:
+    """Extract a Kotlin function (top-level or method)."""
+    name_node = _first_child_by_type(node, "simple_identifier")
+    if name_node is None:
+        return
+    func_name = node_text(name_node)
+    is_method = container_id != module_id
+    func_id = f"{container_id}.{func_name}" if is_method else f"{container_id}:{func_name}"
+
+    params = _extract_parameters(node)
+    return_type = _extract_return_type(node)
+    body = _first_child_by_type(node, "function_body")
+
+    branches, exception_types, calls = _collect_func_body(body, file_path)
+    complexity = compute_complexity(branches)
+
+    unit = CodeUnit(
+        id=func_id,
+        name=func_name,
+        kind=NodeKind.METHOD if is_method else NodeKind.FUNCTION,
+        location=make_location(node, file_path),
+        parameters=tuple(params),
+        return_type=return_type,
+        exception_types=tuple(exception_types),
+        cyclomatic_complexity=complexity,
+        branches=tuple(branches),
+    )
+    graph.nodes[func_id] = unit
+    add_contains_edge(graph, container_id, func_id)
+
+    _add_call_edges(calls, func_id, file_path, graph)
+
+
+def _extract_parameters(node: Node) -> list[Parameter]:
+    """Extract parameters from a function_declaration."""
+    plist = _first_child_by_type(node, "function_value_parameters")
+    if plist is None:
+        return []
+    params: list[Parameter] = []
+    for child in plist.children:
+        if child.type == "parameter":
+            _extract_single_param(child, params)
+    return params
+
+
+def _extract_single_param(decl: Node, params: list[Parameter]) -> None:
+    """Extract one parameter's name and type."""
+    name = ""
+    type_ref: TypeRef | None = None
+    for child in decl.children:
+        if child.type == "simple_identifier" and not name:
+            name = node_text(child)
+        elif child.type in _KOTLIN_TYPE_NODES and type_ref is None:
+            type_ref = TypeRef(name=node_text(child))
+    if name:
+        params.append(Parameter(name=name, type_ref=type_ref))
+
+
+def _extract_return_type(node: Node) -> TypeRef | None:
+    """Return type is the type node after the first `:` on the signature."""
+    saw_colon = False
+    for child in node.children:
+        if child.type == ":":
+            saw_colon = True
+            continue
+        if saw_colon and child.type in _KOTLIN_TYPE_NODES:
+            return TypeRef(name=node_text(child))
+        if child.type == "function_body":
+            # Hit the body before any colon — no explicit return type.
+            return None
+    return None
+
+
+def _collect_func_body(
+    body: Node | None,
+    file_path: str,
+) -> tuple[list[BranchInfo], list[TypeRef], list[tuple[str, Node]]]:
+    branches: list[BranchInfo] = []
+    exception_types: list[TypeRef] = []
+    calls: list[tuple[str, Node]] = []
+    if body is not None:
+        collect_body_info(
+            body,
+            file_path,
+            _BRANCH_NODE_TYPES,
+            "call_expression",
+            _THROW_TYPES,
+            branches,
+            exception_types,
+            calls,
+        )
+    return branches, exception_types, calls
+
+
+def _add_call_edges(
+    calls: list[tuple[str, Node]],
+    source_id: str,
+    file_path: str,
+    graph: CodeGraph,
+) -> None:
+    for call_name, call_node in calls:
+        confidence = EdgeConfidence.CERTAIN if "." not in call_name else EdgeConfidence.INFERRED
+        graph.edges.append(
+            CodeEdge(
+                source_id=source_id,
+                target_id=call_name,
+                kind=EdgeKind.CALLS,
+                confidence=confidence,
+                location=make_location(call_node, file_path),
+            )
+        )
+
+
+def _extract_import(node: Node, graph: CodeGraph) -> None:
+    """Extract `import foo.bar.Baz` declarations as dependencies."""
+    for child in node.children:
+        if child.type == "identifier":
+            raw = node_text(child)
+            # Use the last segment for consistency with other parsers.
+            dep = raw.rsplit(".", 1)[-1]
+            if dep and dep not in graph.dependencies:
+                graph.dependencies.append(dep)
+
+
+def _first_child_by_type(node: Node, type_name: str) -> Node | None:
+    for child in node.children:
+        if child.type == type_name:
+            return child
+    return None

--- a/src/trailmark/query/api.py
+++ b/src/trailmark/query/api.py
@@ -39,6 +39,7 @@ _PARSER_MAP: dict[str, tuple[str, str]] = {
     "masm": ("trailmark.parsers.masm", "MasmParser"),
     "swift": ("trailmark.parsers.swift", "SwiftParser"),
     "objc": ("trailmark.parsers.objc", "ObjCParser"),
+    "kotlin": ("trailmark.parsers.kotlin", "KotlinParser"),
 }
 
 # Extensions used for language auto-detection. Kept in sync with each parser's
@@ -67,6 +68,7 @@ _LANGUAGE_EXTENSIONS: dict[str, tuple[str, ...]] = {
     # `.h` files can be C, ObjC, or C++; auto-detect only fires on .m/.mm.
     # The parser itself still walks .h when invoked with language="objc".
     "objc": (".m", ".mm"),
+    "kotlin": (".kt", ".kts"),
 }
 
 _SUPPORTED_LANGUAGES = frozenset(_PARSER_MAP.keys())

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -586,6 +586,45 @@ class TestObjectiveC:
         assert engine.attack_surface() == []
 
 
+class TestKotlin:
+    def test_spring_annotation_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "UserController.kt").write_text(
+            "import org.springframework.web.bind.annotation.*\n"
+            "\n"
+            "@RestController\n"
+            "class UserController {\n"
+            '    @GetMapping("/users/{id}")\n'
+            '    fun get(id: Long): String { return "ok" }\n'
+            "}\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="kotlin")
+        surface = engine.attack_surface()
+        descriptions = [ep.get("description") or "" for ep in surface]
+        assert any("Spring" in d for d in descriptions), surface
+
+    def test_android_lifecycle_method_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "MainActivity.kt").write_text(
+            "package com.example\n"
+            "\n"
+            "class MainActivity {\n"
+            "    fun onCreate(bundle: Bundle?) {\n"
+            "        super.onCreate(bundle)\n"
+            "    }\n"
+            "}\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="kotlin")
+        surface = engine.attack_surface()
+        descriptions = [ep.get("description") or "" for ep in surface]
+        assert any("Android" in d for d in descriptions), surface
+
+    def test_helper_method_not_flagged(self, tmp_path: Path) -> None:
+        (tmp_path / "Util.kt").write_text(
+            "class Util {\n    fun helper(x: Int): Int { return x + 1 }\n}\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="kotlin")
+        assert engine.attack_surface() == []
+
+
 @pytest.fixture(autouse=True)
 def _isolate_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Some tests create pyproject.toml in tmp_path; make sure detection does

--- a/tests/test_kotlin_parser.py
+++ b/tests/test_kotlin_parser.py
@@ -1,0 +1,113 @@
+"""Tests for the Kotlin parser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from trailmark.models.graph import CodeGraph
+from trailmark.parsers.kotlin import KotlinParser
+
+
+def _parse(tmp_path: Path, body: str, name: str = "App.kt") -> CodeGraph:
+    (tmp_path / name).write_text(body)
+    return KotlinParser().parse_directory(str(tmp_path))
+
+
+class TestBasicExtraction:
+    def test_module_node_created(self, tmp_path: Path) -> None:
+        graph = _parse(tmp_path, "fun greet() {}\n")
+        assert "App" in graph.nodes
+        assert graph.nodes["App"].kind.value == "module"
+
+    def test_top_level_function(self, tmp_path: Path) -> None:
+        graph = _parse(tmp_path, "fun greet() {}\n")
+        assert "App:greet" in graph.nodes
+        assert graph.nodes["App:greet"].kind.value == "function"
+
+    def test_parameters_and_return_type(self, tmp_path: Path) -> None:
+        graph = _parse(
+            tmp_path,
+            "fun add(a: Int, b: Int): Int { return a + b }\n",
+        )
+        func = graph.nodes["App:add"]
+        assert [p.name for p in func.parameters] == ["a", "b"]
+        assert func.return_type is not None
+        assert func.return_type.name == "Int"
+
+    def test_nullable_return_type(self, tmp_path: Path) -> None:
+        graph = _parse(
+            tmp_path,
+            "fun maybe(): User? { return null }\nclass User\n",
+        )
+        func = graph.nodes["App:maybe"]
+        assert func.return_type is not None
+        assert func.return_type.name == "User?"
+
+    def test_class_with_methods(self, tmp_path: Path) -> None:
+        graph = _parse(
+            tmp_path,
+            "class Foo {\n    fun bar(x: Int): Int { return x }\n    private fun baz() {}\n}\n",
+        )
+        assert graph.nodes["App:Foo"].kind.value == "class"
+        assert "App:Foo.bar" in graph.nodes
+        assert "App:Foo.baz" in graph.nodes
+        assert graph.nodes["App:Foo.bar"].kind.value == "method"
+
+    def test_interface_detected(self, tmp_path: Path) -> None:
+        graph = _parse(
+            tmp_path,
+            "interface Repository {\n    fun find(id: Long): String?\n}\n",
+        )
+        assert graph.nodes["App:Repository"].kind.value == "interface"
+        assert "App:Repository.find" in graph.nodes
+
+    def test_data_class_detected(self, tmp_path: Path) -> None:
+        graph = _parse(tmp_path, "data class User(val id: Long)\n")
+        assert graph.nodes["App:User"].kind.value == "class"
+
+
+class TestControlFlow:
+    def test_complexity_counts_when_and_if(self, tmp_path: Path) -> None:
+        code = (
+            "fun classify(x: Int): String {\n"
+            '    if (x < 0) return "neg"\n'
+            "    return when (x) {\n"
+            '        0 -> "zero"\n'
+            '        1 -> "one"\n'
+            '        else -> "many"\n'
+            "    }\n"
+            "}\n"
+        )
+        graph = _parse(tmp_path, code)
+        assert graph.nodes["App:classify"].cyclomatic_complexity is not None
+        assert graph.nodes["App:classify"].cyclomatic_complexity >= 3
+
+
+class TestImports:
+    def test_import_captured(self, tmp_path: Path) -> None:
+        graph = _parse(
+            tmp_path,
+            "import kotlinx.coroutines.runBlocking\nfun f() {}\n",
+        )
+        assert graph.dependencies, "expected at least one dependency"
+
+
+class TestCallEdges:
+    def test_call_edge_recorded(self, tmp_path: Path) -> None:
+        graph = _parse(
+            tmp_path,
+            "fun a() { b() }\nfun b() {}\n",
+        )
+        sources = {e.source_id for e in graph.edges if e.kind.value == "calls"}
+        assert "App:a" in sources
+
+    def test_method_call_via_navigation(self, tmp_path: Path) -> None:
+        graph = _parse(
+            tmp_path,
+            "fun a(b: Thing) { b.run() }\nclass Thing { fun run() {} }\n",
+        )
+        # Call via `b.run()` should produce an INFERRED edge from a.
+        sources_targets = {
+            (e.source_id, e.target_id) for e in graph.edges if e.kind.value == "calls"
+        }
+        assert any(src == "App:a" for src, _ in sources_targets), sources_targets


### PR DESCRIPTION
Handles .kt and .kts files using tree-sitter-language-pack's kotlin grammar (transitive dep, no new installs). Extracts:

- Top-level functions (fun main, suspend fun fetch, ...)
- Classes, interfaces, data classes, objects, enum classes
- Methods inside class_body and enum_class_body
- Parameters from function_value_parameters and their user_type / type_identifier / nullable_type annotations
- Return types from the type node following `:` on the signature
- Imports — captured as graph.dependencies

Entrypoint detectors for Kotlin:

- Spring MVC / WebFlux annotations (@GetMapping, @PostMapping, etc.) reusing the existing Java detector since the annotations are identical across the two languages.
- Android component lifecycle methods: onCreate, onStart, onResume, onNewIntent, onActivityResult, onReceive, onBind, onHandleIntent. These are attacker-reachable when the component is exported — we over-detect on purpose and rely on the override file to tighten.

Known gap (parallel to Swift, documented in parser docstring): `throw` statements share their AST node type with `return`/`break`/`continue` via `jump_expression`, so exception-type capture needs a Kotlin-specific walk filtered by the leading `throw` token. Deferred.

14 new tests: Kotlin parser, Kotlin entrypoint detection. README supported-languages and framework-coverage tables updated.

Roadmap left before v0.2.0: Dart/Flutter parser, Go/Ruby/C++ entrypoint detectors (Option A), branches + docstring in JSON export (Option B).