### PR TITLE
feat(parsers): add Dart / Flutter language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ A language-specific parser walks the directory, parses each file into a tree-sit
 | Swift | `.swift` | functions, classes, structs, enums, protocols, extensions |
 | Objective-C | `.m`, `.mm`, `.h` | C functions, classes, methods (selector-based naming) |
 | Kotlin | `.kt`, `.kts` | functions, classes, interfaces, data classes, objects, methods |
+| Dart | `.dart` | functions, classes, abstract classes, methods, constructors |
 
 ```mermaid
 flowchart TD
@@ -295,6 +296,7 @@ Framework coverage:
 | Swift | `@main` app attribute |
 | Objective-C | `UIApplicationDelegate` lifecycle selectors (e.g. `application:openURL:options:`) |
 | Kotlin | Spring MVC / WebFlux annotations (shared with Java), Android component lifecycle methods (`onCreate`, `onReceive`, `onBind`, ...) |
+| Dart | `@pragma('vm:entry-point')` native-callable markers |
 
 For anything the heuristics miss, declare entrypoints explicitly in `.trailmark/entrypoints.toml` at the project root:
 

--- a/src/trailmark/analysis/entrypoints.py
+++ b/src/trailmark/analysis/entrypoints.py
@@ -189,6 +189,13 @@ _KOTLIN_ANDROID_LIFECYCLE_METHODS = frozenset(
     }
 )
 
+# Dart — `@pragma('vm:entry-point')` marks native-callable functions,
+# often FFI or platform-channel callback targets. These are attacker-
+# reachable from the host platform.
+_DART_VM_ENTRY_POINT = re.compile(
+    r"^\s*@\s*pragma\s*\(\s*['\"]vm:entry-point['\"]",
+)
+
 _KIND_BY_NAME = {k.value: k for k in EntrypointKind}
 _TRUST_BY_NAME = {t.value: t for t in TrustLevel}
 _ASSET_BY_NAME = {a.value: a for a in AssetValue}
@@ -283,6 +290,8 @@ def _detect_for_unit(
         return _detect_objc(unit)
     if path.endswith((".kt", ".kts")):
         return _detect_kotlin(cache, unit, path)
+    if path.endswith(".dart"):
+        return _detect_dart(cache, unit, path)
     return None
 
 
@@ -707,6 +716,33 @@ def _detect_kotlin(
             description="Android component lifecycle method",
             asset_value=AssetValue.HIGH,
         )
+    return None
+
+
+def _detect_dart(
+    cache: _SourceCache,
+    unit: CodeUnit,
+    path: str,
+) -> EntrypointTag | None:
+    """Detect Dart entrypoints.
+
+    Today covers ``@pragma('vm:entry-point')``, the explicit Dart marker
+    for functions invoked from native code (FFI callbacks, platform-
+    channel handlers, deferred loading targets). Flutter lifecycle
+    methods on ``StatefulWidget`` / ``StatelessWidget`` (``build``,
+    ``initState``, ``dispose``) are not flagged here because they
+    execute in-process and aren't directly attacker-reachable —
+    add them via the override file if you want them surfaced.
+    """
+    decorators = cache.decorators_above(path, unit.location.start_line)
+    for line in decorators:
+        if _DART_VM_ENTRY_POINT.match(line):
+            return EntrypointTag(
+                kind=EntrypointKind.API,
+                trust_level=TrustLevel.UNTRUSTED_EXTERNAL,
+                description="Dart @pragma('vm:entry-point') native callback",
+                asset_value=AssetValue.HIGH,
+            )
     return None
 
 

--- a/src/trailmark/parsers/dart/__init__.py
+++ b/src/trailmark/parsers/dart/__init__.py
@@ -1,0 +1,5 @@
+"""Dart language parser for Trailmark."""
+
+from trailmark.parsers.dart.parser import DartParser
+
+__all__ = ["DartParser"]

--- a/src/trailmark/parsers/dart/parser.py
+++ b/src/trailmark/parsers/dart/parser.py
@@ -1,0 +1,504 @@
+"""Dart language parser using tree-sitter.
+
+Targets Dart source used in Flutter apps and command-line Dart programs.
+The Dart grammar splits each function into two sibling nodes —
+``function_signature`` (or ``method_signature`` inside a class) followed
+by ``function_body`` — so the extractor walks siblings and pairs them.
+
+Extracts:
+
+- Top-level functions (``function_signature`` + ``function_body``).
+- Classes (``class_definition``) and abstract classes.
+- Methods inside class bodies (``method_signature`` + ``function_body``).
+- Parameters from ``formal_parameter_list`` → ``formal_parameter``.
+- Return types from the first type node on the signature.
+- Imports (``library_import`` → ``import_specification``).
+- Annotations tracked as they precede a declaration so
+  ``@pragma('vm:entry-point')`` can be surfaced to the entrypoint detector.
+
+Known gap: ``throw`` statements are not currently captured into
+``exception_types``. The ``throw_expression`` node exists but Dart also
+exposes standalone ``throw``-statement forms that need a dedicated walk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tree_sitter import Node
+from tree_sitter_language_pack import get_parser
+
+from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
+from trailmark.models.graph import CodeGraph
+from trailmark.models.nodes import (
+    BranchInfo,
+    CodeUnit,
+    NodeKind,
+    Parameter,
+    SourceLocation,
+    TypeRef,
+)
+from trailmark.parsers._common import (
+    add_contains_edge,
+    add_module_node,
+    collect_body_info,
+    compute_complexity,
+    make_location,
+    module_id_from_path,
+    node_text,
+    parse_directory,
+)
+
+_EXTENSIONS = (".dart",)
+
+_BRANCH_NODE_TYPES = frozenset(
+    {
+        "if_statement",
+        "for_statement",
+        "while_statement",
+        "do_statement",
+        "switch_statement",
+        "switch_case",
+        "switch_default",
+        "try_statement",
+        "catch_clause",
+    }
+)
+
+_THROW_TYPES: frozenset[str] = frozenset()
+
+_DART_TYPE_NODES = frozenset(
+    {
+        "type_identifier",
+        "void_type",
+        "nullable_type",
+        "function_type",
+    }
+)
+
+
+class DartParser:
+    """Parses Dart source files into CodeGraph using tree-sitter."""
+
+    @property
+    def language(self) -> str:
+        return "dart"
+
+    def __init__(self) -> None:
+        self._parser = get_parser("dart")
+
+    def parse_file(self, file_path: str) -> CodeGraph:
+        """Parse a single .dart file into a CodeGraph."""
+        source = Path(file_path).read_bytes()
+        tree = self._parser.parse(source)
+        graph = CodeGraph(language="dart", root_path=file_path)
+        module_id = module_id_from_path(file_path)
+        _visit_module(tree.root_node, file_path, module_id, graph)
+        return graph
+
+    def parse_directory(self, dir_path: str) -> CodeGraph:
+        """Parse all Dart source files under dir_path."""
+        return parse_directory(
+            self.parse_file,
+            "dart",
+            dir_path,
+            _EXTENSIONS,
+        )
+
+
+def _visit_module(
+    root: Node,
+    file_path: str,
+    module_id: str,
+    graph: CodeGraph,
+) -> None:
+    add_module_node(root, file_path, module_id, graph)
+    _walk_siblings(root.children, file_path, module_id, module_id, graph)
+
+
+def _walk_siblings(
+    children: list[Node],
+    file_path: str,
+    module_id: str,
+    container_id: str,
+    graph: CodeGraph,
+) -> None:
+    """Walk a list of sibling nodes, pairing signatures with bodies.
+
+    Dart emits ``function_signature`` / ``method_signature`` followed by
+    a sibling ``function_body``. Annotations appear as ``annotation``
+    siblings immediately before the declaration they apply to — we track
+    the pending-annotation-set so detectors can see them later.
+    """
+    pending_annotations: list[Node] = []
+    idx = 0
+    while idx < len(children):
+        node = children[idx]
+        if node.type == "annotation":
+            pending_annotations.append(node)
+            idx += 1
+            continue
+        if node.type == "import_or_export":
+            _extract_import(node, graph)
+            pending_annotations.clear()
+        elif node.type == "class_definition":
+            _extract_class(node, file_path, module_id, graph)
+            pending_annotations.clear()
+        elif node.type in {"function_signature", "method_signature"}:
+            body = children[idx + 1] if idx + 1 < len(children) else None
+            if body is not None and body.type == "function_body":
+                _extract_function_from_signature(
+                    node,
+                    body,
+                    file_path,
+                    module_id,
+                    container_id,
+                    pending_annotations,
+                    graph,
+                )
+                idx += 1  # Also consume the body node.
+            else:
+                _extract_function_from_signature(
+                    node,
+                    None,
+                    file_path,
+                    module_id,
+                    container_id,
+                    pending_annotations,
+                    graph,
+                )
+            pending_annotations.clear()
+        elif node.type == "declaration":
+            # Abstract method in a class body — wraps either a
+            # method_signature or function_signature without a body.
+            for member in node.children:
+                if member.type in {"method_signature", "function_signature"}:
+                    _extract_function_from_signature(
+                        member,
+                        None,
+                        file_path,
+                        module_id,
+                        container_id,
+                        pending_annotations,
+                        graph,
+                    )
+                    break
+            pending_annotations.clear()
+        else:
+            # Anything else — class body separator, comments — clears pending
+            # annotations unless it's whitespace-y content that doesn't carry
+            # meaning.
+            if node.type not in {"comment", ";", "{", "}"}:
+                pending_annotations.clear()
+        idx += 1
+
+
+def _extract_class(
+    node: Node,
+    file_path: str,
+    module_id: str,
+    graph: CodeGraph,
+) -> None:
+    """Extract a Dart class (including abstract classes)."""
+    name_node = _first_child_by_type(node, "identifier")
+    if name_node is None:
+        return
+    class_name = node_text(name_node)
+    class_id = f"{module_id}:{class_name}"
+    graph.nodes[class_id] = CodeUnit(
+        id=class_id,
+        name=class_name,
+        kind=NodeKind.CLASS,
+        location=make_location(node, file_path),
+    )
+    add_contains_edge(graph, module_id, class_id)
+
+    body = _first_child_by_type(node, "class_body")
+    if body is None:
+        return
+    _walk_siblings(body.children, file_path, module_id, class_id, graph)
+
+
+def _extract_function_from_signature(
+    signature: Node,
+    body: Node | None,
+    file_path: str,
+    module_id: str,
+    container_id: str,
+    pending_annotations: list[Node],
+    graph: CodeGraph,
+) -> None:
+    """Pair a signature with its body (if present) into a CodeUnit."""
+    inner = _unwrap_method_signature(signature)
+    name_node = _function_name_node(inner)
+    if name_node is None:
+        return
+    func_name = node_text(name_node)
+    is_method = container_id != module_id
+    func_id = f"{container_id}.{func_name}" if is_method else f"{container_id}:{func_name}"
+
+    params = _extract_parameters(inner)
+    return_type = _extract_return_type(inner)
+
+    span_end = body if body is not None else signature
+
+    branches, exception_types, calls = _collect_func_body(body, file_path)
+    complexity = compute_complexity(branches)
+
+    location = make_location(signature, file_path)
+    # Extend the end line to cover the body too.
+    if body is not None:
+        location = _merge_locations(signature, body, file_path)
+
+    unit = CodeUnit(
+        id=func_id,
+        name=func_name,
+        kind=NodeKind.METHOD if is_method else NodeKind.FUNCTION,
+        location=location,
+        parameters=tuple(params),
+        return_type=return_type,
+        exception_types=tuple(exception_types),
+        cyclomatic_complexity=complexity,
+        branches=tuple(branches),
+    )
+    graph.nodes[func_id] = unit
+    add_contains_edge(graph, container_id, func_id)
+
+    # Attach annotation texts as audit-visible annotations so detectors
+    # can find them via the node's enclosing file scan.
+    for ann in pending_annotations:
+        _ = ann  # kept for readability; detection happens via source scan
+    _ = span_end
+    _add_call_edges(calls, func_id, file_path, graph)
+
+
+def _unwrap_method_signature(node: Node) -> Node:
+    """Return the inner function_signature inside a method_signature wrapper."""
+    if node.type == "method_signature":
+        inner = _first_child_by_type(node, "function_signature")
+        if inner is not None:
+            return inner
+    return node
+
+
+def _function_name_node(signature: Node) -> Node | None:
+    """Find the ``identifier`` that names the function (not type identifiers)."""
+    seen_type = False
+    for child in signature.children:
+        if child.type in _DART_TYPE_NODES:
+            seen_type = True
+            continue
+        if child.type == "type_arguments":
+            continue
+        if child.type == "identifier":
+            if seen_type:
+                return child
+            # No explicit return type (e.g., constructor) — the first
+            # identifier is the name.
+            return child
+    return None
+
+
+def _extract_parameters(signature: Node) -> list[Parameter]:
+    """Extract parameters from a function_signature's formal_parameter_list."""
+    plist = _first_child_by_type(signature, "formal_parameter_list")
+    if plist is None:
+        return []
+    params: list[Parameter] = []
+    for child in plist.children:
+        if child.type == "formal_parameter":
+            _extract_single_param(child, params)
+    return params
+
+
+def _extract_single_param(decl: Node, params: list[Parameter]) -> None:
+    """Extract one formal_parameter."""
+    name = ""
+    type_ref: TypeRef | None = None
+    for child in decl.children:
+        if child.type in _DART_TYPE_NODES and type_ref is None:
+            type_ref = TypeRef(name=node_text(child))
+        elif child.type == "identifier" and not name:
+            name = node_text(child)
+        elif child.type == "constructor_param":
+            # `this.name` — grab the trailing identifier.
+            for sub in child.children:
+                if sub.type == "identifier":
+                    name = node_text(sub)
+                    break
+    if name:
+        params.append(Parameter(name=name, type_ref=type_ref))
+
+
+def _extract_return_type(signature: Node) -> TypeRef | None:
+    """The first type-bearing child is the declared return type."""
+    for child in signature.children:
+        if child.type in _DART_TYPE_NODES:
+            return TypeRef(name=node_text(child))
+        if child.type == "identifier":
+            # Reached the name before any return type — treat as implicit.
+            return None
+    return None
+
+
+def _collect_func_body(
+    body: Node | None,
+    file_path: str,
+) -> tuple[list[BranchInfo], list[TypeRef], list[tuple[str, Node]]]:
+    branches: list[BranchInfo] = []
+    exception_types: list[TypeRef] = []
+    calls: list[tuple[str, Node]] = []
+    if body is not None:
+        # Branches use the shared helper; Dart represents a call as an
+        # `identifier` / `selector` sibling pair rather than a single call
+        # node, so calls need a dedicated walk.
+        collect_body_info(
+            body,
+            file_path,
+            _BRANCH_NODE_TYPES,
+            # Pass a sentinel that will never match so collect_body_info
+            # skips its own call extraction; we handle calls separately.
+            "__dart_calls_collected_separately__",
+            _THROW_TYPES,
+            branches,
+            exception_types,
+            calls,
+        )
+        _collect_dart_calls(body, calls)
+    return branches, exception_types, calls
+
+
+def _collect_dart_calls(body: Node, calls: list[tuple[str, Node]]) -> None:
+    """Find call sites in a Dart body.
+
+    Dart's AST renders ``foo()`` as two sibling nodes under an
+    ``expression_statement`` or similar: an ``identifier`` followed by a
+    ``selector`` that contains an ``argument_part``. Method calls
+    ``obj.method()`` expand the identifier to a longer chain of
+    ``identifier`` + ``selector`` + ``identifier`` + ... with the final
+    selector holding the argument_part.
+    """
+    stack: list[Node] = list(body.children)
+    while stack:
+        node = stack.pop()
+        # Check each pair of adjacent children inside this node for the
+        # "callee identifier -> arguments-bearing selector" pattern.
+        children = node.children
+        for idx, child in enumerate(children):
+            if child.type != "selector":
+                continue
+            if not _selector_has_arguments(child):
+                continue
+            name = _resolve_dart_callee(children, idx)
+            if name:
+                calls.append((name, child))
+        stack.extend(children)
+
+
+def _selector_has_arguments(selector: Node) -> bool:
+    """True if a ``selector`` node carries an ``argument_part`` (a call)."""
+    return any(child.type == "argument_part" for child in selector.children)
+
+
+def _resolve_dart_callee(children: list[Node], selector_idx: int) -> str:
+    """Reconstruct the callee name from the prefix preceding a selector.
+
+    Looks backwards from the selector collecting adjacent identifiers and
+    non-argument selectors that build up a dotted name, e.g.
+    ``obj.method`` from ``identifier('obj')`` + ``selector('.method')`` +
+    argument-bearing ``selector('()')``.
+    """
+    parts: list[str] = []
+    i = selector_idx - 1
+    while i >= 0:
+        prev = children[i]
+        if prev.type == "identifier":
+            parts.append(node_text(prev))
+            i -= 1
+            continue
+        if prev.type == "selector" and not _selector_has_arguments(prev):
+            # e.g. `.method` — extract the identifier inside.
+            inner = _selector_identifier(prev)
+            if inner:
+                parts.append(inner)
+                i -= 1
+                continue
+            break
+        break
+    if not parts:
+        return ""
+    parts.reverse()
+    return ".".join(parts)
+
+
+def _selector_identifier(selector: Node) -> str:
+    """Pull the identifier out of a dotted selector like `.method`."""
+    for child in selector.children:
+        if child.type == "identifier":
+            return node_text(child)
+    return ""
+
+
+def _add_call_edges(
+    calls: list[tuple[str, Node]],
+    source_id: str,
+    file_path: str,
+    graph: CodeGraph,
+) -> None:
+    for call_name, call_node in calls:
+        confidence = EdgeConfidence.CERTAIN if "." not in call_name else EdgeConfidence.INFERRED
+        graph.edges.append(
+            CodeEdge(
+                source_id=source_id,
+                target_id=call_name,
+                kind=EdgeKind.CALLS,
+                confidence=confidence,
+                location=make_location(call_node, file_path),
+            )
+        )
+
+
+def _extract_import(node: Node, graph: CodeGraph) -> None:
+    """Capture `import 'package:foo/bar.dart';` style imports."""
+    for child in node.children:
+        if child.type == "library_import":
+            _extract_library_import(child, graph)
+
+
+def _extract_library_import(node: Node, graph: CodeGraph) -> None:
+    spec = _first_child_by_type(node, "import_specification")
+    if spec is None:
+        return
+    raw_text = node_text(spec)
+    # Pull the quoted URI and use its last path segment minus .dart.
+    for quote in ("'", '"'):
+        if quote in raw_text:
+            parts = raw_text.split(quote)
+            if len(parts) >= 2:
+                uri = parts[1]
+                dep = uri.rsplit("/", 1)[-1].removesuffix(".dart")
+                if dep and dep not in graph.dependencies:
+                    graph.dependencies.append(dep)
+                return
+
+
+def _merge_locations(
+    start_node: Node,
+    end_node: Node,
+    file_path: str,
+) -> SourceLocation:
+    """Build a SourceLocation spanning two sibling nodes."""
+    return SourceLocation(
+        file_path=file_path,
+        start_line=start_node.start_point.row + 1,
+        end_line=end_node.end_point.row + 1,
+        start_col=start_node.start_point.column,
+        end_col=end_node.end_point.column,
+    )
+
+
+def _first_child_by_type(node: Node, type_name: str) -> Node | None:
+    for child in node.children:
+        if child.type == type_name:
+            return child
+    return None

--- a/src/trailmark/query/api.py
+++ b/src/trailmark/query/api.py
@@ -40,6 +40,7 @@ _PARSER_MAP: dict[str, tuple[str, str]] = {
     "swift": ("trailmark.parsers.swift", "SwiftParser"),
     "objc": ("trailmark.parsers.objc", "ObjCParser"),
     "kotlin": ("trailmark.parsers.kotlin", "KotlinParser"),
+    "dart": ("trailmark.parsers.dart", "DartParser"),
 }
 
 # Extensions used for language auto-detection. Kept in sync with each parser's
@@ -69,6 +70,7 @@ _LANGUAGE_EXTENSIONS: dict[str, tuple[str, ...]] = {
     # The parser itself still walks .h when invoked with language="objc".
     "objc": (".m", ".mm"),
     "kotlin": (".kt", ".kts"),
+    "dart": (".dart",),
 }
 
 _SUPPORTED_LANGUAGES = frozenset(_PARSER_MAP.keys())

--- a/tests/test_dart_parser.py
+++ b/tests/test_dart_parser.py
@@ -1,0 +1,95 @@
+"""Tests for the Dart parser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from trailmark.models.graph import CodeGraph
+from trailmark.parsers.dart import DartParser
+
+
+def _parse(tmp_path: Path, body: str, name: str = "app.dart") -> CodeGraph:
+    (tmp_path / name).write_text(body)
+    return DartParser().parse_directory(str(tmp_path))
+
+
+class TestBasicExtraction:
+    def test_module_node_created(self, tmp_path: Path) -> None:
+        graph = _parse(tmp_path, "void greet() {}\n")
+        assert "app" in graph.nodes
+        assert graph.nodes["app"].kind.value == "module"
+
+    def test_top_level_function(self, tmp_path: Path) -> None:
+        graph = _parse(tmp_path, "void greet() {}\n")
+        assert "app:greet" in graph.nodes
+        assert graph.nodes["app:greet"].kind.value == "function"
+
+    def test_parameters_and_return_type(self, tmp_path: Path) -> None:
+        graph = _parse(
+            tmp_path,
+            "int add(int a, int b) { return a + b; }\n",
+        )
+        func = graph.nodes["app:add"]
+        assert [p.name for p in func.parameters] == ["a", "b"]
+        assert func.return_type is not None
+        assert func.return_type.name == "int"
+
+    def test_void_return_type(self, tmp_path: Path) -> None:
+        graph = _parse(tmp_path, "void log(String s) {}\n")
+        func = graph.nodes["app:log"]
+        assert func.return_type is not None
+        assert func.return_type.name == "void"
+
+    def test_class_with_methods(self, tmp_path: Path) -> None:
+        graph = _parse(
+            tmp_path,
+            "class Foo {\n  int bar(int x) { return x; }\n  void baz() {}\n}\n",
+        )
+        assert graph.nodes["app:Foo"].kind.value == "class"
+        assert "app:Foo.bar" in graph.nodes
+        assert "app:Foo.baz" in graph.nodes
+        assert graph.nodes["app:Foo.bar"].kind.value == "method"
+
+    def test_abstract_method_extracted(self, tmp_path: Path) -> None:
+        graph = _parse(
+            tmp_path,
+            "abstract class Repo {\n  int findById(int id);\n}\n",
+        )
+        assert "app:Repo.findById" in graph.nodes
+
+
+class TestControlFlow:
+    def test_complexity_counts_branches(self, tmp_path: Path) -> None:
+        code = (
+            "String classify(int x) {\n"
+            "  if (x < 0) { return 'neg'; }\n"
+            "  switch (x) {\n"
+            "    case 0: return 'zero';\n"
+            "    case 1: return 'one';\n"
+            "    default: return 'many';\n"
+            "  }\n"
+            "}\n"
+        )
+        graph = _parse(tmp_path, code)
+        assert graph.nodes["app:classify"].cyclomatic_complexity is not None
+        assert graph.nodes["app:classify"].cyclomatic_complexity >= 3
+
+
+class TestImports:
+    def test_package_import_captured(self, tmp_path: Path) -> None:
+        graph = _parse(
+            tmp_path,
+            "import 'package:flutter/material.dart';\nvoid f() {}\n",
+        )
+        assert graph.dependencies, "expected at least one dependency"
+        assert any("material" in d for d in graph.dependencies)
+
+
+class TestCallEdges:
+    def test_call_edge_recorded(self, tmp_path: Path) -> None:
+        graph = _parse(
+            tmp_path,
+            "void a() { b(); }\nvoid b() {}\n",
+        )
+        sources = {e.source_id for e in graph.edges if e.kind.value == "calls"}
+        assert "app:a" in sources

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -625,6 +625,32 @@ class TestKotlin:
         assert engine.attack_surface() == []
 
 
+class TestDart:
+    def test_vm_entry_point_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "callbacks.dart").write_text(
+            "@pragma('vm:entry-point')\nvoid nativeCallback(String data) {\n  print(data);\n}\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="dart")
+        surface = engine.attack_surface()
+        descriptions = [ep.get("description") or "" for ep in surface]
+        assert any("vm:entry-point" in d for d in descriptions), surface
+
+    def test_plain_function_not_flagged(self, tmp_path: Path) -> None:
+        (tmp_path / "util.dart").write_text(
+            "void log(String s) { print(s); }\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="dart")
+        assert engine.attack_surface() == []
+
+    def test_main_still_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "app.dart").write_text(
+            "void main() { print('hi'); }\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="dart")
+        surface = engine.attack_surface()
+        assert any(ep["node_id"] == "app:main" for ep in surface), surface
+
+
 @pytest.fixture(autouse=True)
 def _isolate_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Some tests create pyproject.toml in tmp_path; make sure detection does


### PR DESCRIPTION
Uses tree-sitter-language-pack's dart grammar (transitive dep, no new installs). Extracts:

- Top-level functions (paired from function_signature + function_body sibling nodes; Dart's grammar keeps them as separate AST siblings rather than nesting them, which required a custom signature-pairing walker).
- Classes, including abstract classes.
- Methods inside class bodies (method_signature + function_body pairs).
- Abstract methods (declaration -> function_signature, no body).
- Parameters and return types.
- Imports — `package:` and `dart:` URIs captured as dependencies.

Calls in Dart aren't a single AST node — they're an identifier followed by a selector carrying an argument_part. Added _collect_dart_calls to walk bodies, detect argument-bearing selectors, and reconstruct the callee name from the preceding identifier/selector chain (handles both plain calls `b()` and method calls `obj.method()`).

Entrypoint detector:

- `@pragma('vm:entry-point')` — Dart's explicit native-callable marker. Used for FFI callbacks, platform-channel handlers, and deferred loading targets; these are attacker-reachable from the host platform.

Flutter lifecycle methods (`build`, `initState`, `dispose`) are NOT flagged by default because they run in-process and aren't directly attacker-reachable. Users who want them tagged can add them via the override file.

Known gaps (documented in the parser docstring): `throw` statements aren't yet added to exception_types — parallel to Swift/Kotlin, the throw AST node overlaps with other control-transfer forms.

12 new tests: Dart parser, Dart entrypoint detection. README supported-languages and framework-coverage tables updated.

Roadmap left before v0.2.0: Option A (Go/Ruby/C++ entrypoint detectors) and Option B (branches + docstring in JSON export).