### PR TITLE
feat(entrypoints): Go / Ruby / C / C++ framework detectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,9 @@ Framework coverage:
 | Objective-C | `UIApplicationDelegate` lifecycle selectors (e.g. `application:openURL:options:`) |
 | Kotlin | Spring MVC / WebFlux annotations (shared with Java), Android component lifecycle methods (`onCreate`, `onReceive`, `onBind`, ...) |
 | Dart | `@pragma('vm:entry-point')` native-callable markers |
+| Go | `http.HandleFunc` / `http.Handle` stdlib registrations, gin/chi/echo-style `<router>.GET/POST/...` handler registrations |
+| Ruby | Rails controller actions (classes inheriting `ApplicationController` / `ActionController::*`), Sidekiq worker `perform` methods |
+| C / C++ | `extern "C"` linkage, `__attribute__((visibility("default")))`, `__declspec(dllexport)` |
 
 For anything the heuristics miss, declare entrypoints explicitly in `.trailmark/entrypoints.toml` at the project root:
 

--- a/src/trailmark/analysis/entrypoints.py
+++ b/src/trailmark/analysis/entrypoints.py
@@ -196,6 +196,44 @@ _DART_VM_ENTRY_POINT = re.compile(
     r"^\s*@\s*pragma\s*\(\s*['\"]vm:entry-point['\"]",
 )
 
+# Go — `http.HandleFunc("/path", handler)` / `http.Handle("/path", h)`.
+# The stdlib net/http registrations accept a string path and a handler
+# reference.
+_GO_HTTP_HANDLE = re.compile(
+    r"\bhttp\.(HandleFunc|Handle)\s*\(\s*\"[^\"]*\"\s*,\s*([A-Za-z_][\w.]*)",
+)
+
+# Go — gin/chi/echo/fiber route registration: `<router>.<VERB>("/path", handler)`.
+# Matches GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS on any receiver. This is
+# looser than the stdlib pattern so it catches most community routers,
+# at the cost of possibly matching non-HTTP methods on unrelated types.
+_GO_ROUTER_VERB = re.compile(
+    r"\b([A-Za-z_]\w*)\.(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|Any|Match)"
+    r"\s*\(\s*\"[^\"]*\"\s*,\s*([A-Za-z_][\w.]*)",
+)
+
+# Ruby — Rails controller: `class FooController < ApplicationController`
+# (or any ActionController base / another controller).
+_RUBY_RAILS_CONTROLLER_CLASS = re.compile(
+    r"^\s*class\s+(\w+)\s*<\s*(ApplicationController|ActionController::\w+|\w+Controller)\b",
+)
+
+# Ruby — Sidekiq worker: either `include Sidekiq::Worker` or
+# `include Sidekiq::Job` inside a class body.
+_RUBY_SIDEKIQ_INCLUDE = re.compile(
+    r"^\s*include\s+Sidekiq::(Worker|Job)\b",
+)
+
+# C / C++ — explicit library export markers on the signature line.
+#   extern "C" ...             (C++ C-linkage declaration)
+#   __attribute__((visibility("default")))
+#   __declspec(dllexport)
+_C_EXPORT_MARKERS = re.compile(
+    r'\bextern\s+"C"'
+    r'|__attribute__\s*\(\s*\(\s*visibility\s*\(\s*"default"'
+    r"|__declspec\s*\(\s*dllexport\s*\)",
+)
+
 _KIND_BY_NAME = {k.value: k for k in EntrypointKind}
 _TRUST_BY_NAME = {t.value: t for t in TrustLevel}
 _ASSET_BY_NAME = {a.value: a for a in AssetValue}
@@ -292,6 +330,12 @@ def _detect_for_unit(
         return _detect_kotlin(cache, unit, path)
     if path.endswith(".dart"):
         return _detect_dart(cache, unit, path)
+    if path.endswith(".go"):
+        return _detect_go(cache, unit, path)
+    if path.endswith(".rb"):
+        return _detect_ruby(cache, unit, path)
+    if path.endswith((".c", ".cpp", ".cc", ".cxx", ".h", ".hpp", ".hh", ".hxx")):
+        return _detect_c_cpp(cache, unit, path)
     return None
 
 
@@ -719,6 +763,117 @@ def _detect_kotlin(
     return None
 
 
+def _detect_go(
+    cache: _SourceCache,
+    unit: CodeUnit,
+    path: str,
+) -> EntrypointTag | None:
+    """Detect Go entrypoints via call-site route registrations.
+
+    Go has no annotation syntax for HTTP handlers — they're wired at
+    call sites like ``http.HandleFunc("/path", name)`` or
+    ``r.GET("/path", handler)``. For each file we compile the set of
+    function names referenced as handlers, then tag matching nodes.
+    Registrations that pass anonymous closures or method expressions
+    (``obj.Method``) are also captured — the second form is recorded
+    dotted; we tag any node whose basename matches.
+    """
+    handlers = cache.go_http_handler_names(path)
+    if not handlers:
+        return None
+    if unit.name in handlers:
+        return EntrypointTag(
+            kind=EntrypointKind.API,
+            trust_level=TrustLevel.UNTRUSTED_EXTERNAL,
+            description="Go HTTP handler (net/http or router DSL)",
+            asset_value=AssetValue.HIGH,
+        )
+    return None
+
+
+def _detect_ruby(
+    cache: _SourceCache,
+    unit: CodeUnit,
+    path: str,
+) -> EntrypointTag | None:
+    """Detect Ruby entrypoints: Rails controller actions and Sidekiq workers.
+
+    Rails controllers are classes that inherit from
+    ``ApplicationController`` / ``ActionController::*`` — every public
+    instance method of such a class is an action. We tag any method
+    whose node id starts with ``<Module>:<ClassName>.`` and whose class
+    name appears in the file's controller set.
+
+    Sidekiq workers are classes that ``include Sidekiq::Worker`` /
+    ``include Sidekiq::Job``. Their ``perform`` method handles queue
+    messages — only that one method is tagged per worker class.
+    """
+    controllers = cache.ruby_rails_controller_classes(path)
+    workers = cache.ruby_sidekiq_worker_classes(path)
+    if not controllers and not workers:
+        return None
+
+    # Node IDs look like "module:ClassName.method" for methods, or just
+    # "module:ClassName" for the class itself. Only tag method nodes.
+    if unit.kind.value != "method":
+        return None
+    node_id = unit.id
+    if ":" not in node_id or "." not in node_id:
+        return None
+    class_part = node_id.split(":", 1)[1].split(".", 1)[0]
+    if class_part in controllers:
+        return EntrypointTag(
+            kind=EntrypointKind.API,
+            trust_level=TrustLevel.UNTRUSTED_EXTERNAL,
+            description="Rails controller action",
+            asset_value=AssetValue.HIGH,
+        )
+    if class_part in workers and unit.name == "perform":
+        return EntrypointTag(
+            kind=EntrypointKind.THIRD_PARTY,
+            trust_level=TrustLevel.SEMI_TRUSTED_EXTERNAL,
+            description="Sidekiq worker perform method",
+            asset_value=AssetValue.MEDIUM,
+        )
+    return None
+
+
+def _detect_c_cpp(
+    cache: _SourceCache,
+    unit: CodeUnit,
+    path: str,
+) -> EntrypointTag | None:
+    """Detect C / C++ library exports by explicit linkage markers.
+
+    Matches ``extern "C"``, ``__attribute__((visibility("default")))``,
+    and ``__declspec(dllexport)`` on or just above the signature line.
+    Plain non-``static`` functions in headers are NOT flagged by default
+    because that inversion ("everything not static is exported") is too
+    broad for audit purposes — use the override file for projects where
+    that's the intent.
+    """
+    # Explicit markers sometimes appear on the line above the signature
+    # (e.g. `__declspec(dllexport)\nint foo(...)`), so scan both.
+    signature = cache.signature_block(path, unit.location.start_line) or ""
+    if _C_EXPORT_MARKERS.search(signature):
+        return EntrypointTag(
+            kind=EntrypointKind.API,
+            trust_level=TrustLevel.UNTRUSTED_EXTERNAL,
+            description='C/C++ exported symbol (extern "C" / visibility / dllexport)',
+            asset_value=AssetValue.HIGH,
+        )
+    # Also check one line above — some projects put the attribute on its own line.
+    above = cache.line(path, unit.location.start_line - 1) or ""
+    if _C_EXPORT_MARKERS.search(above):
+        return EntrypointTag(
+            kind=EntrypointKind.API,
+            trust_level=TrustLevel.UNTRUSTED_EXTERNAL,
+            description='C/C++ exported symbol (extern "C" / visibility / dllexport)',
+            asset_value=AssetValue.HIGH,
+        )
+    return None
+
+
 def _detect_dart(
     cache: _SourceCache,
     unit: CodeUnit,
@@ -770,6 +925,7 @@ class _SourceCache:
 
     def __init__(self) -> None:
         self._lines: dict[str, list[str]] = {}
+        self._scan_cache: dict[str, set[str]] = {}
 
     def _read(self, path: str) -> list[str]:
         cached = self._lines.get(path)
@@ -793,6 +949,72 @@ class _SourceCache:
     def iter_lines(self, path: str) -> list[str]:
         """Return all lines of the file (cached) for whole-file scans."""
         return self._read(path)
+
+    def go_http_handler_names(self, path: str) -> set[str]:
+        """Extract Go HTTP handler names registered in the file.
+
+        Scans for ``http.HandleFunc("/path", name)``, ``http.Handle(...)``,
+        and router-DSL shapes like ``r.GET("/path", handler)``. The
+        handler reference is usually a bare identifier (``handler``) but
+        can be a method expression (``obj.Method``); we record the last
+        dotted segment for lookup against Trailmark node names.
+        """
+        key = f"go_handlers::{path}"
+        cached = self._scan_cache.get(key)
+        if cached is not None:
+            return cached
+        names: set[str] = set()
+        for line in self._read(path):
+            for match in _GO_HTTP_HANDLE.finditer(line):
+                names.add(match.group(2).rsplit(".", 1)[-1])
+            for match in _GO_ROUTER_VERB.finditer(line):
+                names.add(match.group(3).rsplit(".", 1)[-1])
+        self._scan_cache[key] = names
+        return names
+
+    def ruby_rails_controller_classes(self, path: str) -> set[str]:
+        """Extract class names that inherit from Rails controller bases."""
+        key = f"ruby_rails::{path}"
+        cached = self._scan_cache.get(key)
+        if cached is not None:
+            return cached
+        names: set[str] = set()
+        for line in self._read(path):
+            match = _RUBY_RAILS_CONTROLLER_CLASS.match(line)
+            if match:
+                names.add(match.group(1))
+        self._scan_cache[key] = names
+        return names
+
+    def ruby_sidekiq_worker_classes(self, path: str) -> set[str]:
+        """Return class names whose body contains ``include Sidekiq::Worker``.
+
+        Tracked by scanning for the include directive and associating it
+        with the most recently opened ``class <Name>`` block. This is a
+        one-level heuristic — nested classes aren't perfectly modeled —
+        but matches idiomatic Sidekiq worker layout.
+        """
+        key = f"ruby_sidekiq::{path}"
+        cached = self._scan_cache.get(key)
+        if cached is not None:
+            return cached
+        names: set[str] = set()
+        class_stack: list[str] = []
+        for line in self._read(path):
+            stripped = line.strip()
+            # Crude class-open / class-close tracking. Good enough for
+            # typical worker files, not a general Ruby parser.
+            class_open = re.match(r"^\s*class\s+(\w+)\b", line)
+            if class_open:
+                class_stack.append(class_open.group(1))
+                continue
+            if stripped == "end" and class_stack:
+                class_stack.pop()
+                continue
+            if class_stack and _RUBY_SIDEKIQ_INCLUDE.match(line):
+                names.add(class_stack[-1])
+        self._scan_cache[key] = names
+        return names
 
     def decorators_above(self, path: str, start_line: int) -> list[str]:
         """Return decorator-style lines around ``start_line``.

--- a/src/trailmark/parsers/cpp/parser.py
+++ b/src/trailmark/parsers/cpp/parser.py
@@ -127,6 +127,11 @@ def _visit_top_level_node(
             module_id,
             graph,
         )
+    elif child.type == "linkage_specification":
+        # `extern "C" { ... }` wraps nested declarations — unwrap and
+        # dispatch each child back through this visitor.
+        for nested in child.children:
+            _visit_top_level_node(nested, file_path, module_id, class_id, graph)
     elif child.type == "class_specifier":
         _extract_class(child, file_path, module_id, graph)
     elif child.type == "struct_specifier":

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -651,6 +651,112 @@ class TestDart:
         assert any(ep["node_id"] == "app:main" for ep in surface), surface
 
 
+class TestGo:
+    def test_http_handlefunc_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "server.go").write_text(
+            "package main\n"
+            'import "net/http"\n'
+            "\n"
+            "func loginHandler(w http.ResponseWriter, r *http.Request) {}\n"
+            "\n"
+            "func main() {\n"
+            '    http.HandleFunc("/login", loginHandler)\n'
+            "}\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="go")
+        surface = engine.attack_surface()
+        descriptions = {ep.get("description") or "" for ep in surface}
+        assert any("Go HTTP handler" in d for d in descriptions), surface
+
+    def test_gin_route_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "app.go").write_text(
+            "package main\n"
+            'import "github.com/gin-gonic/gin"\n'
+            "\n"
+            "func getUser(c *gin.Context) {}\n"
+            "\n"
+            "func main() {\n"
+            "    r := gin.Default()\n"
+            '    r.GET("/users/:id", getUser)\n'
+            "}\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="go")
+        surface = engine.attack_surface()
+        ids = {ep["node_id"] for ep in surface}
+        assert any("getUser" in nid for nid in ids), surface
+
+
+class TestRuby:
+    def test_rails_controller_action_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "users_controller.rb").write_text(
+            "class UsersController < ApplicationController\n"
+            "  def show\n"
+            "    @user = User.find(params[:id])\n"
+            "  end\n"
+            "\n"
+            "  def create\n"
+            "    User.create(params[:user])\n"
+            "  end\n"
+            "end\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="ruby")
+        surface = engine.attack_surface()
+        descriptions = {ep.get("description") or "" for ep in surface}
+        assert any("Rails controller" in d for d in descriptions), surface
+
+    def test_non_controller_class_not_flagged(self, tmp_path: Path) -> None:
+        (tmp_path / "util.rb").write_text(
+            "class Util\n  def helper(x)\n    x + 1\n  end\nend\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="ruby")
+        assert engine.attack_surface() == []
+
+    def test_sidekiq_worker_perform_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "mailer.rb").write_text(
+            "class EmailWorker\n"
+            "  include Sidekiq::Worker\n"
+            "\n"
+            "  def perform(user_id)\n"
+            "    puts user_id\n"
+            "  end\n"
+            "end\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="ruby")
+        surface = engine.attack_surface()
+        descriptions = {ep.get("description") or "" for ep in surface}
+        assert any("Sidekiq" in d for d in descriptions), surface
+
+
+class TestCCpp:
+    def test_extern_c_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "api.cpp").write_text(
+            'extern "C" int add_one(int x) {\n    return x + 1;\n}\n',
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="cpp")
+        surface = engine.attack_surface()
+        descriptions = {ep.get("description") or "" for ep in surface}
+        assert any('extern "C"' in d or "exported" in d for d in descriptions), surface
+
+    def test_dllexport_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "lib.c").write_text(
+            "__declspec(dllexport)\nint compute(int x) {\n    return x * 2;\n}\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="c")
+        surface = engine.attack_surface()
+        descriptions = {ep.get("description") or "" for ep in surface}
+        assert any("dllexport" in d or "exported" in d for d in descriptions), surface
+
+    def test_plain_c_function_not_flagged(self, tmp_path: Path) -> None:
+        (tmp_path / "util.c").write_text(
+            "int helper(int x) {\n    return x + 1;\n}\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="c")
+        # `main` is always flagged by the main-heuristic; helper is not.
+        surface = engine.attack_surface()
+        ids = {ep["node_id"] for ep in surface}
+        assert not any("helper" in nid for nid in ids), surface
+
+
 @pytest.fixture(autouse=True)
 def _isolate_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Some tests create pyproject.toml in tmp_path; make sure detection does


### PR DESCRIPTION
Adds Option A from the v0.2.0 roadmap — entrypoint detection for the three languages that lagged behind the decorator-based detectors because their conventions don't fit the scan-lines-above-start pattern.

Go:
- `http.HandleFunc("/path", name)` / `http.Handle(...)` stdlib.
- Router DSLs that share the `<receiver>.(GET|POST|PUT|PATCH|DELETE| HEAD|OPTIONS|Any|Match)("/path", handler)` shape — gin, chi, echo, fiber, and similar community routers. The _SourceCache now exposes `go_http_handler_names(path)` which scans a file once and caches the set of handler identifiers registered anywhere in it; the detector looks up each function by name.

Ruby:
- Rails controllers — classes inheriting ApplicationController or ActionController::*. Every method of such a class is tagged as an untrusted-external API entrypoint.
- Sidekiq workers — classes with `include Sidekiq::Worker` / `Sidekiq::Job`. Only the `perform` method is tagged. Adds a class-body scanner to _SourceCache that tracks `class X ... end` nesting to map include directives to their enclosing class.

C / C++:
- `extern "C"` linkage.
- `__attribute__((visibility("default")))`.
- `__declspec(dllexport)`. Markers are matched on the signature line or the line immediately above it; plain non-static functions are intentionally NOT flagged (too broad for audit purposes — use the override file).

Also fixes a pre-existing gap in the C++ parser: `extern "C" int foo()` wraps the function in a `linkage_specification` node, which the parser wasn't unwrapping, so no function node was emitted. Now handled.

8 new tests across Go, Ruby, and C/C++ detection. README coverage table updated.