### PR TITLE
feat(entrypoints): rule-based bulk overrides in entrypoints.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,18 +301,50 @@ Framework coverage:
 | Ruby | Rails controller actions (classes inheriting `ApplicationController` / `ActionController::*`), Sidekiq worker `perform` methods |
 | C / C++ | `extern "C"` linkage, `__attribute__((visibility("default")))`, `__declspec(dllexport)` |
 
-For anything the heuristics miss, declare entrypoints explicitly in `.trailmark/entrypoints.toml` at the project root:
+For anything the heuristics miss, declare entrypoints explicitly in `.trailmark/entrypoints.toml` at the project root. The file supports both single-node and rule-based entries:
 
 ```toml
+# Single-node entry
 [[entrypoint]]
 node = "my_module:handle_request"  # node id, or "module.path:function"
 kind = "api"                       # user_input | api | database | file_system | third_party
 trust = "untrusted_external"       # untrusted_external | semi_trusted_external | trusted_internal
 asset_value = "high"               # high | medium | low
 description = "HTTP POST /auth"
+
+# Rule: every PHP script under public_html/ is a web-exposed entrypoint.
+[[entrypoint]]
+file_glob = "public_html/**/*.php"
+kind = "user_input"
+trust = "untrusted_external"
+asset_value = "high"
+description = "Web-exposed PHP script"
+
+# Rule: any function that takes a PSR-7 request object.
+[[entrypoint]]
+param_type = "ServerRequestInterface"
+kind = "api"
+trust = "untrusted_external"
+asset_value = "high"
+description = "PSR-7 HTTP handler"
+
+# Rule: functions named `handle_*`.
+[[entrypoint]]
+name_regex = "^handle_"
+kind = "api"
+trust = "untrusted_external"
+
+# Rule: conditions compose with AND — web.py files AND name starts with handle_.
+[[entrypoint]]
+file_glob = "public/*.py"
+name_regex = "^handle_"
+kind = "api"
+trust = "untrusted_external"
 ```
 
-See [docs/entrypoint-patterns.md](docs/entrypoint-patterns.md) for the full reference, including frameworks not yet implemented (Express / Koa / Fastify, Laravel, Rails, Cobra, axum, warp, clap, and others) with grep-ready patterns contributors can use to add new detectors.
+Later entries override earlier ones when two rules tag the same node, so place broad rules first and specific corrections after.
+
+See [docs/entrypoint-patterns.md](docs/entrypoint-patterns.md) for the full reference, including frameworks not yet implemented (Express / Koa / Fastify, Laravel, Cobra, axum, warp, clap, and others) with grep-ready patterns contributors can use to add new detectors.
 
 ### Programmatic API
 

--- a/src/trailmark/analysis/entrypoints.py
+++ b/src/trailmark/analysis/entrypoints.py
@@ -1164,14 +1164,44 @@ def _load_override_file(
 ) -> dict[str, EntrypointTag]:
     """Parse ``.trailmark/entrypoints.toml`` into EntrypointTag entries.
 
-    Expected schema:
+    An entry may identify a single node by id or reference, OR declare a
+    rule that matches many nodes at once. Rule-based entries accept any
+    combination of:
 
+    - ``file_glob``: match ``CodeUnit.location.file_path`` against a
+      shell glob supporting ``**`` (recursive) and ``*`` (single-segment).
+    - ``param_type``: match functions whose parameter list includes a
+      declared type with this name (exact ``TypeRef.name`` match).
+    - ``name_regex``: match functions whose ``name`` satisfies the regex.
+
+    When multiple conditions are supplied in one entry they are combined
+    with AND. Later entries in the file override earlier ones when two
+    rules would tag the same node.
+
+    Examples:
+
+        # Single-node (unchanged)
         [[entrypoint]]
-        node = "cli:main"          # node id OR "module.path:function"
-        kind = "api"               # EntrypointKind value
-        trust = "untrusted_external"  # TrustLevel value (optional)
-        asset_value = "high"       # AssetValue value (optional)
-        description = "HTTP handler"  # optional
+        node = "cli:main"
+        kind = "api"
+
+        # All PHP scripts under public_html/
+        [[entrypoint]]
+        file_glob = "public_html/**/*.php"
+        kind = "user_input"
+        trust = "untrusted_external"
+        asset_value = "high"
+
+        # Any function that takes a PSR-7 request
+        [[entrypoint]]
+        param_type = "ServerRequestInterface"
+        kind = "api"
+        trust = "untrusted_external"
+
+        # Functions whose name starts with `handle_`
+        [[entrypoint]]
+        name_regex = "^handle_"
+        kind = "api"
     """
     path = repo_root / OVERRIDE_FILE
     if not path.exists():
@@ -1190,25 +1220,48 @@ def _load_override_file(
     for entry in entries:
         if not isinstance(entry, dict):
             continue
-        tag_and_id = _entry_to_tag(graph, entry)
-        if tag_and_id is None:
-            continue
-        node_id, tag = tag_and_id
-        result[node_id] = tag
+        for node_id, tag in _entry_to_matches(graph, entry):
+            result[node_id] = tag
     return result
 
 
-def _entry_to_tag(
+def _entry_to_matches(
     graph: CodeGraph,
     entry: dict[str, Any],
-) -> tuple[str, EntrypointTag] | None:
-    node_ref = entry.get("node")
-    if not isinstance(node_ref, str):
-        return None
-    node_id = _resolve_override_node(graph, node_ref)
-    if node_id is None:
-        return None
+) -> list[tuple[str, EntrypointTag]]:
+    """Produce every (node_id, tag) pair an override-file entry implies.
 
+    Returns an empty list if the entry is malformed, references an
+    unknown node, or matches nothing.
+    """
+    tag = _entry_tag(entry)
+    if tag is None:
+        return []
+
+    node_ref = entry.get("node")
+    if isinstance(node_ref, str):
+        node_id = _resolve_override_node(graph, node_ref)
+        if node_id is None:
+            return []
+        return [(node_id, tag)]
+
+    # Rule-based entry — compile match conditions.
+    conditions = _compile_rule_conditions(entry)
+    if conditions is None:
+        # No recognized rule fields (and no `node`); nothing to do.
+        return []
+
+    matches: list[tuple[str, EntrypointTag]] = []
+    for node_id, unit in graph.nodes.items():
+        if unit.kind.value not in {"function", "method"}:
+            continue
+        if all(condition(unit) for condition in conditions):
+            matches.append((node_id, tag))
+    return matches
+
+
+def _entry_tag(entry: dict[str, Any]) -> EntrypointTag | None:
+    """Build the EntrypointTag shared across every match of an entry."""
     kind_name = entry.get("kind", "user_input")
     trust_name = entry.get("trust", "untrusted_external")
     asset_name = entry.get("asset_value", "medium")
@@ -1220,12 +1273,106 @@ def _entry_to_tag(
     if kind is None or trust is None or asset is None:
         return None
 
-    return node_id, EntrypointTag(
+    return EntrypointTag(
         kind=kind,
         trust_level=trust,
         description=description if isinstance(description, str) else None,
         asset_value=asset,
     )
+
+
+def _compile_rule_conditions(
+    entry: dict[str, Any],
+) -> list[Any] | None:
+    """Translate rule fields into predicates evaluated per CodeUnit.
+
+    Returns None if the entry contains no recognized rule fields.
+    """
+    conditions: list[Any] = []
+    file_glob = entry.get("file_glob")
+    if isinstance(file_glob, str):
+        try:
+            pattern = _glob_to_regex(file_glob)
+        except re.error:
+            return None
+        conditions.append(
+            lambda unit, p=pattern: bool(
+                p.search((unit.location.file_path or "").replace("\\", "/"))
+            ),
+        )
+
+    param_type = entry.get("param_type")
+    if isinstance(param_type, str):
+        conditions.append(
+            lambda unit, t=param_type: any(
+                p.type_ref is not None and p.type_ref.name == t for p in unit.parameters
+            ),
+        )
+
+    name_regex = entry.get("name_regex")
+    if isinstance(name_regex, str):
+        try:
+            pattern = re.compile(name_regex)
+        except re.error:
+            return None
+        conditions.append(
+            lambda unit, p=pattern: bool(p.search(unit.name)),
+        )
+
+    return conditions or None
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate a shell-style glob with ``**`` support into a regex.
+
+    - ``**`` (with surrounding slashes) matches zero or more path segments.
+    - ``*`` matches any characters except ``/``.
+    - ``?`` matches one character other than ``/``.
+    - Other regex metacharacters are escaped.
+
+    Paths are matched against their string form, with both Windows and
+    POSIX separators normalized to ``/`` before comparison is done by
+    the caller of this function (``_glob_match`` below). We only emit
+    the regex here.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(pattern)
+    while i < n:
+        c = pattern[i]
+        if c == "*" and i + 1 < n and pattern[i + 1] == "*":
+            # `/**/` expands to `(?:/.*)?/` — zero or more segments.
+            if i > 0 and pattern[i - 1] == "/" and i + 2 < n and pattern[i + 2] == "/":
+                # Rewrite the trailing `/` of the preceding segment as
+                # part of the globstar expansion.
+                out[-1] = "(?:/.*)?/"
+                i += 3
+                continue
+            # Leading `**/` or trailing `/**`.
+            if i + 2 < n and pattern[i + 2] == "/":
+                out.append("(?:.*/)?")
+                i += 3
+                continue
+            out.append(".*")
+            i += 2
+        elif c == "*":
+            out.append("[^/]*")
+            i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        elif c in r".+^$()[]{}|\\":
+            out.append("\\" + c)
+            i += 1
+        else:
+            out.append(c)
+            i += 1
+    # Allow the pattern to match a suffix of the full path — users
+    # writing `public_html/**/*.php` shouldn't have to prefix the full
+    # absolute path of the project. `re.search` finds the pattern
+    # anywhere in the string, so we just anchor the end.
+    regex = "(?:^|/)" + "".join(out) + "$"
+    return re.compile(regex)
 
 
 def _resolve_override_node(graph: CodeGraph, reference: str) -> str | None:

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -757,6 +757,183 @@ class TestCCpp:
         assert not any("helper" in nid for nid in ids), surface
 
 
+class TestBulkOverrideRules:
+    """Rule-based .trailmark/entrypoints.toml entries."""
+
+    def _write_override(self, tmp_path: Path, body: str) -> None:
+        (tmp_path / ".trailmark").mkdir(exist_ok=True)
+        (tmp_path / ".trailmark" / "entrypoints.toml").write_text(body)
+
+    def test_file_glob_marks_every_matching_function(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / "public_html").mkdir()
+        (tmp_path / "public_html" / "index.php").write_text(
+            "<?php\nfunction index() { return 1; }\n",
+        )
+        (tmp_path / "public_html" / "admin").mkdir()
+        (tmp_path / "public_html" / "admin" / "login.php").write_text(
+            "<?php\nfunction login() { return 2; }\n",
+        )
+        (tmp_path / "lib.php").write_text(
+            "<?php\nfunction helper() { return 3; }\n",
+        )
+        self._write_override(
+            tmp_path,
+            "[[entrypoint]]\n"
+            'file_glob = "public_html/**/*.php"\n'
+            'kind = "user_input"\n'
+            'trust = "untrusted_external"\n'
+            'asset_value = "high"\n'
+            'description = "Web-exposed PHP"\n',
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="php")
+        surface = engine.attack_surface()
+        ids = {ep["node_id"] for ep in surface}
+        # Both public_html scripts — at any nesting depth — are tagged;
+        # the lib.php function is not.
+        assert any(nid.endswith(":index") for nid in ids), ids
+        assert any(nid.endswith(":login") for nid in ids), ids
+        assert not any(nid.endswith(":helper") for nid in ids), ids
+
+    def test_file_glob_single_star_does_not_cross_directories(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """`public/*.py` should NOT match a nested file."""
+        (tmp_path / "public").mkdir()
+        (tmp_path / "public" / "index.py").write_text("def index(): pass\n")
+        (tmp_path / "public" / "admin").mkdir()
+        (tmp_path / "public" / "admin" / "deep.py").write_text("def deep(): pass\n")
+        self._write_override(
+            tmp_path,
+            "[[entrypoint]]\n"
+            'file_glob = "public/*.py"\n'
+            'kind = "api"\n'
+            'trust = "untrusted_external"\n',
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="python")
+        ids = {ep["node_id"] for ep in engine.attack_surface()}
+        assert any(nid.endswith(":index") for nid in ids), ids
+        assert not any(nid.endswith(":deep") for nid in ids), ids
+
+    def test_param_type_matches_psr7(self, tmp_path: Path) -> None:
+        (tmp_path / "handlers.py").write_text(
+            "def handle_login(req: ServerRequestInterface) -> None:\n"
+            "    pass\n"
+            "\n"
+            "def unrelated(x: int) -> None:\n"
+            "    pass\n",
+        )
+        self._write_override(
+            tmp_path,
+            "[[entrypoint]]\n"
+            'param_type = "ServerRequestInterface"\n'
+            'kind = "api"\n'
+            'trust = "untrusted_external"\n'
+            'asset_value = "high"\n'
+            'description = "PSR-7 HTTP handler"\n',
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="python")
+        surface = engine.attack_surface()
+        by_id = {ep["node_id"]: ep for ep in surface}
+        assert "handlers:handle_login" in by_id, surface
+        assert by_id["handlers:handle_login"]["description"] == "PSR-7 HTTP handler"
+        assert not any(nid.endswith(":unrelated") for nid in by_id)
+
+    def test_name_regex_matches(self, tmp_path: Path) -> None:
+        (tmp_path / "api.py").write_text(
+            "def handle_login(req):\n"
+            "    pass\n"
+            "\n"
+            "def handle_logout(req):\n"
+            "    pass\n"
+            "\n"
+            "def internal_helper(x):\n"
+            "    pass\n",
+        )
+        self._write_override(
+            tmp_path,
+            '[[entrypoint]]\nname_regex = "^handle_"\nkind = "api"\ntrust = "untrusted_external"\n',
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="python")
+        ids = {ep["node_id"] for ep in engine.attack_surface()}
+        assert "api:handle_login" in ids
+        assert "api:handle_logout" in ids
+        assert "api:internal_helper" not in ids
+
+    def test_conditions_compose_with_and(self, tmp_path: Path) -> None:
+        """When an entry has multiple conditions, all must match."""
+        (tmp_path / "public").mkdir()
+        (tmp_path / "public" / "web.py").write_text(
+            "def handle_login(req):\n    pass\n",
+        )
+        (tmp_path / "public" / "util.py").write_text(
+            "def helper(x):\n    pass\n",
+        )
+        (tmp_path / "internal.py").write_text(
+            "def handle_internal(x):\n    pass\n",
+        )
+        self._write_override(
+            tmp_path,
+            "[[entrypoint]]\n"
+            'file_glob = "public/*.py"\n'
+            'name_regex = "^handle_"\n'
+            'kind = "api"\n'
+            'trust = "untrusted_external"\n',
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="python")
+        ids = {ep["node_id"] for ep in engine.attack_surface()}
+        # In public/ AND matches name_regex -> yes
+        assert "web:handle_login" in ids
+        # In public/ but fails name_regex -> no
+        assert "util:helper" not in ids
+        # Matches name_regex but not in public/ -> no
+        assert "internal:handle_internal" not in ids
+
+    def test_rule_overrides_heuristic(self, tmp_path: Path) -> None:
+        """Rule-based entries still apply the override-wins precedence."""
+        (tmp_path / "tool.py").write_text("def main(): pass\n")
+        self._write_override(
+            tmp_path,
+            "[[entrypoint]]\n"
+            'name_regex = "^main$"\n'
+            'kind = "api"\n'
+            'trust = "untrusted_external"\n'
+            'asset_value = "high"\n',
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="python")
+        (ep,) = engine.attack_surface()
+        # Heuristic would have tagged user_input / trusted_internal / low;
+        # the rule overrides to api / untrusted_external / high.
+        assert ep["kind"] == "api"
+        assert ep["trust_level"] == "untrusted_external"
+        assert ep["asset_value"] == "high"
+
+    def test_malformed_glob_does_not_crash(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text("def main(): pass\n")
+        self._write_override(
+            tmp_path,
+            "[[entrypoint]]\n"
+            'file_glob = "public/["\n'  # unclosed bracket → regex error
+            'kind = "api"\n',
+        )
+        # Should still succeed; the malformed rule is skipped and the
+        # main() heuristic still fires.
+        engine = QueryEngine.from_directory(str(tmp_path), language="python")
+        assert engine.attack_surface()
+
+    def test_rule_matching_zero_nodes_is_noop(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text("def real(): pass\n")
+        self._write_override(
+            tmp_path,
+            '[[entrypoint]]\nname_regex = "^never_matches$"\nkind = "api"\n',
+        )
+        engine = QueryEngine.from_directory(str(tmp_path), language="python")
+        assert engine.attack_surface() == []
+
+
 @pytest.fixture(autouse=True)
 def _isolate_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Some tests create pyproject.toml in tmp_path; make sure detection does


### PR DESCRIPTION
The override file previously accepted only single-node entries; tagging every PHP script in public_html/ or every function taking a PSR-7 request required listing each function by id. This adds rule-based entries that match many nodes at once.

Three new fields on `[[entrypoint]]` tables (any combination; multiple compose with AND):

- `file_glob = "public_html/**/*.php"` — match against CodeUnit.location.file_path with a shell glob supporting `**` (recursive) and `*` (single-segment).
- `param_type = "ServerRequestInterface"` — match any function whose parameter list includes a declared type with this name.
- `name_regex = "^handle_"` — match function names via regex.

Conditions inside an entry compose with AND. Later entries in the file override earlier ones — same precedence rule as before.

`_glob_to_regex` translates shell globs into regexes with explicit `**` handling so the feature works on Python 3.12 (which lacks `PurePath.full_match`). Paths are normalized to forward slashes before matching so the same pattern works on Windows.

Malformed patterns (bad regex, bad glob) are silently skipped so one broken rule can't disable the whole override file.

8 new tests: file_glob at various depths, single-star scoping, param_type matching, name_regex, AND composition, rule-over-heuristic precedence, malformed glob tolerance, and zero-match non-error.

README documents each rule type with examples, including the canonical "mark all PHP scripts in public_html/" and "mark any function taking a PSR-7 request" cases from the design discussion.