### PR TITLE
Public parse api

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,8 +50,12 @@ Linux (CI runs on Ubuntu without issue).
 
 ## Architecture
 
-Trailmark has a three-layer architecture:
+Trailmark has a parse layer followed by a three-layer analysis stack:
 
+0. **Parse API** (`src/trailmark/parse.py`) -- public entry point for
+   parsing files or directories into a raw `CodeGraph`. Lazily imports
+   the appropriate language parser. Used directly for parse-only
+   workflows and internally by `QueryEngine`.
 1. **CodeGraph** (`src/trailmark/models/graph.py`) -- mutable data
    container holding nodes, edges, annotations, and entrypoints.
 2. **GraphStore** (`src/trailmark/storage/graph_store.py`) -- wraps
@@ -75,6 +79,7 @@ Trailmark has a three-layer architecture:
 
 1. Create `src/trailmark/parsers/<lang>/parser.py` implementing the
    `BaseParser` protocol from `src/trailmark/parsers/base.py`.
-2. Register the language in `src/trailmark/parsers/__init__.py`.
+2. Register the parser in `_PARSER_MAP` and its file extensions in
+   `_LANGUAGE_EXTENSIONS`, both in `src/trailmark/parse.py`.
 3. Add tests in `tests/test_<lang>_parser.py`.
 4. Update the language table in `README.md`.

--- a/README.md
+++ b/README.md
@@ -367,7 +367,12 @@ See [docs/entrypoint-patterns.md](docs/entrypoint-patterns.md) for the full refe
 ### Programmatic API
 
 ```python
+from trailmark.parse import parse_directory, parse_file
 from trailmark.query.api import QueryEngine
+
+# Parse-only API: get the raw CodeGraph without building GraphStore/QueryEngine.
+graph = parse_file("path/to/file.py")
+graph = parse_directory("path/to/project", language="auto")
 
 # Single-language (default) or auto-detect + merge across all languages
 engine = QueryEngine.from_directory("path/to/project")

--- a/src/trailmark/__init__.py
+++ b/src/trailmark/__init__.py
@@ -1,3 +1,16 @@
 """Trailmark: Parse source code into queryable graphs for security analysis."""
 
+from trailmark.parse import (
+    detect_languages,
+    parse_directory,
+    parse_file,
+    supported_languages,
+)
+
+__all__ = [
+    "detect_languages",
+    "parse_directory",
+    "parse_file",
+    "supported_languages",
+]
 __version__ = "0.2.2"

--- a/src/trailmark/parse.py
+++ b/src/trailmark/parse.py
@@ -66,6 +66,7 @@ _LANGUAGE_EXTENSIONS: dict[str, tuple[str, ...]] = {
 
 _SUPPORTED_LANGUAGES = tuple(_PARSER_MAP.keys())
 
+
 def supported_languages() -> tuple[str, ...]:
     """Return the supported Trailmark parser language names."""
     return _SUPPORTED_LANGUAGES

--- a/src/trailmark/parse.py
+++ b/src/trailmark/parse.py
@@ -1,0 +1,215 @@
+"""Public parse-only API for building raw Trailmark code graphs."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+
+from trailmark.models.graph import CodeGraph
+from trailmark.parsers._common import should_skip_dir
+from trailmark.parsers.base import LanguageParser
+
+_PARSER_MAP: dict[str, tuple[str, str]] = {
+    "python": ("trailmark.parsers.python", "PythonParser"),
+    "javascript": ("trailmark.parsers.javascript", "JavaScriptParser"),
+    "typescript": ("trailmark.parsers.typescript", "TypeScriptParser"),
+    "php": ("trailmark.parsers.php", "PHPParser"),
+    "ruby": ("trailmark.parsers.ruby", "RubyParser"),
+    "c": ("trailmark.parsers.c", "CParser"),
+    "cpp": ("trailmark.parsers.cpp", "CppParser"),
+    "c_sharp": ("trailmark.parsers.csharp", "CSharpParser"),
+    "java": ("trailmark.parsers.java", "JavaParser"),
+    "go": ("trailmark.parsers.go", "GoParser"),
+    "rust": ("trailmark.parsers.rust", "RustParser"),
+    "solidity": ("trailmark.parsers.solidity", "SolidityParser"),
+    "cairo": ("trailmark.parsers.cairo", "CairoParser"),
+    "circom": ("trailmark.parsers.circom", "CircomParser"),
+    "haskell": ("trailmark.parsers.haskell", "HaskellParser"),
+    "erlang": ("trailmark.parsers.erlang", "ErlangParser"),
+    "masm": ("trailmark.parsers.masm", "MasmParser"),
+    "swift": ("trailmark.parsers.swift", "SwiftParser"),
+    "objc": ("trailmark.parsers.objc", "ObjCParser"),
+    "kotlin": ("trailmark.parsers.kotlin", "KotlinParser"),
+    "dart": ("trailmark.parsers.dart", "DartParser"),
+}
+
+# Extensions used for language auto-detection. Keep these aligned with each
+# parser's internal _EXTENSIONS tuple. Shared extensions (e.g., `.h` between C
+# and C++) are handled by prioritizing the more specific language — C++ is
+# tried before plain C when both report files.
+_LANGUAGE_EXTENSIONS: dict[str, tuple[str, ...]] = {
+    "python": (".py",),
+    "javascript": (".js", ".jsx", ".mjs", ".cjs"),
+    "typescript": (".ts", ".tsx"),
+    "php": (".php",),
+    "ruby": (".rb",),
+    "c": (".c",),
+    "cpp": (".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx"),
+    "c_sharp": (".cs",),
+    "java": (".java",),
+    "go": (".go",),
+    "rust": (".rs",),
+    "solidity": (".sol",),
+    "cairo": (".cairo",),
+    "circom": (".circom",),
+    "haskell": (".hs",),
+    "erlang": (".erl",),
+    "masm": (".masm",),
+    "swift": (".swift",),
+    # `.h` files can be C, ObjC, or C++; auto-detect only fires on .m/.mm.
+    # The parser itself still walks .h when invoked with language="objc".
+    "objc": (".m", ".mm"),
+    "kotlin": (".kt", ".kts"),
+    "dart": (".dart",),
+}
+
+_SUPPORTED_LANGUAGES = tuple(_PARSER_MAP.keys())
+
+def supported_languages() -> tuple[str, ...]:
+    """Return the supported Trailmark parser language names."""
+    return _SUPPORTED_LANGUAGES
+
+
+def parse_file(path: str, language: str | None = None) -> CodeGraph:
+    """Parse a single file into a raw ``CodeGraph``.
+
+    Args:
+        path: Source file to parse.
+        language: Optional explicit parser language. If omitted, language is
+            inferred from the file extension.
+
+    Raises:
+        ValueError: If the language is unsupported or cannot be inferred.
+    """
+    file_path = Path(path)
+    resolved_language = _resolve_file_language(file_path, language)
+    return _get_parser(resolved_language).parse_file(str(file_path))
+
+
+def parse_directory(path: str, language: str = "python") -> CodeGraph:
+    """Parse a directory into a raw ``CodeGraph``.
+
+    ``language`` accepts a specific language name (e.g. ``"python"``),
+    ``"auto"`` to detect and merge all supported languages found under the
+    directory, or a comma-separated list like ``"python,rust"``.
+    """
+    languages = _resolve_directory_languages(path, language)
+    return _parse_and_merge(path, languages)
+
+
+def detect_languages(path: str) -> list[str]:
+    """Return the sorted languages with at least one file under ``path``.
+
+    Detection walks the directory once, classifies each file by extension,
+    and returns the languages that have at least one match. Order is the
+    order languages are registered in ``_LANGUAGE_EXTENSIONS``, which
+    roughly corresponds to popularity and keeps deterministic behavior.
+    """
+    root = Path(path)
+    if not root.exists():
+        return []
+
+    ext_to_language: dict[str, str] = {}
+    for lang, exts in _LANGUAGE_EXTENSIONS.items():
+        for ext in exts:
+            # When languages share an extension (none currently do, but
+            # guard against it), the FIRST registration wins.
+            ext_to_language.setdefault(ext, lang)
+
+    found: set[str] = set()
+    for _dirpath, dirs, files in os.walk(root):
+        # Keep detection aligned with the parser walk rules.
+        dirs[:] = [d for d in dirs if not should_skip_dir(d)]
+        for name in files:
+            ext = _file_extension(name)
+            if ext in ext_to_language:
+                found.add(ext_to_language[ext])
+        if len(found) == len(_LANGUAGE_EXTENSIONS):
+            break
+
+    return [lang for lang in _LANGUAGE_EXTENSIONS if lang in found]
+
+
+def _get_parser(language: str) -> LanguageParser:
+    """Lazily import and instantiate a parser for the given language."""
+    entry = _PARSER_MAP.get(language)
+    if entry is None:
+        msg = f"Unsupported language: {language}"
+        raise ValueError(msg)
+    module = importlib.import_module(entry[0])
+    cls = getattr(module, entry[1])
+    return cls()
+
+
+def _resolve_file_language(path: Path, language: str | None) -> str:
+    """Resolve a single-file parse request to one concrete language."""
+    if language is None or language == "auto":
+        detected = _detect_file_language(path)
+        if detected is None:
+            msg = f"Could not infer supported language from file extension: {path}"
+            raise ValueError(msg)
+        return detected
+    if "," in language:
+        msg = f"Single-file parse requires one language, got: {language}"
+        raise ValueError(msg)
+    if language not in _PARSER_MAP:
+        msg = f"Unsupported language: {language}"
+        raise ValueError(msg)
+    return language
+
+
+def _resolve_directory_languages(path: str, spec: str) -> list[str]:
+    """Expand a directory ``language`` argument into concrete languages."""
+    if spec == "auto":
+        detected = detect_languages(path)
+        if not detected:
+            msg = f"No supported languages detected under {path}"
+            raise ValueError(msg)
+        return detected
+    names = [name.strip() for name in spec.split(",") if name.strip()] if "," in spec else [spec]
+    for name in names:
+        if name not in _PARSER_MAP:
+            msg = f"Unsupported language: {name}"
+            raise ValueError(msg)
+    return names
+
+
+def _parse_and_merge(path: str, languages: list[str]) -> CodeGraph:
+    """Parse ``path`` with each language parser and merge into one graph."""
+    if len(languages) == 1:
+        # Preserves pre-polyglot behavior exactly for the common case.
+        return _get_parser(languages[0]).parse_directory(path)
+
+    merged = CodeGraph(language="polyglot", root_path=str(Path(path).resolve()))
+    for lang in languages:
+        sub = _get_parser(lang).parse_directory(path)
+        merged.merge(sub)
+    # merge() doesn't touch `language`; preserve the polyglot marker.
+    merged.language = "polyglot"
+    return merged
+
+
+def _detect_file_language(path: Path) -> str | None:
+    """Infer one supported language from a file extension."""
+    ext = _file_extension(path.name)
+    for language, exts in _LANGUAGE_EXTENSIONS.items():
+        if ext in exts:
+            return language
+    return None
+
+
+def _file_extension(name: str) -> str:
+    """Return the lowercase extension including leading dot, or ``''``."""
+    dot = name.rfind(".")
+    if dot < 0:
+        return ""
+    return name[dot:].lower()
+
+
+__all__ = [
+    "detect_languages",
+    "parse_directory",
+    "parse_file",
+    "supported_languages",
+]

--- a/src/trailmark/parsers/_common.py
+++ b/src/trailmark/parsers/_common.py
@@ -104,6 +104,11 @@ _EXCLUDED_DIRS = frozenset(
 )
 
 
+def should_skip_dir(dirname: str) -> bool:
+    """Return whether a directory should be skipped during source walks."""
+    return dirname in _EXCLUDED_DIRS or dirname.startswith(".")
+
+
 def walk_source_files(
     dir_path: str,
     extensions: tuple[str, ...],
@@ -114,7 +119,7 @@ def walk_source_files(
     and does not follow symlinks.
     """
     for root, dirs, files in os.walk(dir_path, followlinks=False):
-        dirs[:] = [d for d in dirs if d not in _EXCLUDED_DIRS and not d.startswith(".")]
+        dirs[:] = [d for d in dirs if not should_skip_dir(d)]
         for fname in sorted(files):
             if any(fname.endswith(ext) for ext in extensions):
                 yield os.path.join(root, fname)

--- a/src/trailmark/query/api.py
+++ b/src/trailmark/query/api.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import importlib
 import json
 from dataclasses import asdict
-from pathlib import Path
 from typing import Any
 
+import trailmark.parse as _parse_api
 from trailmark.analysis.augment import augment_from_sarif, augment_from_weaudit
 from trailmark.analysis.diff import compute_diff
 from trailmark.analysis.entrypoints import detect_entrypoints
@@ -16,186 +15,15 @@ from trailmark.models.annotations import Annotation, AnnotationKind
 from trailmark.models.edges import CodeEdge
 from trailmark.models.graph import CodeGraph
 from trailmark.models.nodes import CodeUnit
-from trailmark.parsers.base import LanguageParser
 from trailmark.storage.graph_store import GraphStore
-
-_PARSER_MAP: dict[str, tuple[str, str]] = {
-    "python": ("trailmark.parsers.python", "PythonParser"),
-    "javascript": ("trailmark.parsers.javascript", "JavaScriptParser"),
-    "typescript": ("trailmark.parsers.typescript", "TypeScriptParser"),
-    "php": ("trailmark.parsers.php", "PHPParser"),
-    "ruby": ("trailmark.parsers.ruby", "RubyParser"),
-    "c": ("trailmark.parsers.c", "CParser"),
-    "cpp": ("trailmark.parsers.cpp", "CppParser"),
-    "c_sharp": ("trailmark.parsers.csharp", "CSharpParser"),
-    "java": ("trailmark.parsers.java", "JavaParser"),
-    "go": ("trailmark.parsers.go", "GoParser"),
-    "rust": ("trailmark.parsers.rust", "RustParser"),
-    "solidity": ("trailmark.parsers.solidity", "SolidityParser"),
-    "cairo": ("trailmark.parsers.cairo", "CairoParser"),
-    "circom": ("trailmark.parsers.circom", "CircomParser"),
-    "haskell": ("trailmark.parsers.haskell", "HaskellParser"),
-    "erlang": ("trailmark.parsers.erlang", "ErlangParser"),
-    "masm": ("trailmark.parsers.masm", "MasmParser"),
-    "swift": ("trailmark.parsers.swift", "SwiftParser"),
-    "objc": ("trailmark.parsers.objc", "ObjCParser"),
-    "kotlin": ("trailmark.parsers.kotlin", "KotlinParser"),
-    "dart": ("trailmark.parsers.dart", "DartParser"),
-}
-
-# Extensions used for language auto-detection. Kept in sync with each parser's
-# internal _EXTENSIONS tuple. Shared extensions (e.g., `.h` between C and C++)
-# are handled by prioritizing the more specific language — C++ is tried before
-# plain C when both report files.
-_LANGUAGE_EXTENSIONS: dict[str, tuple[str, ...]] = {
-    "python": (".py",),
-    "javascript": (".js", ".jsx", ".mjs", ".cjs"),
-    "typescript": (".ts", ".tsx"),
-    "php": (".php",),
-    "ruby": (".rb",),
-    "c": (".c",),
-    "cpp": (".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx"),
-    "c_sharp": (".cs",),
-    "java": (".java",),
-    "go": (".go",),
-    "rust": (".rs",),
-    "solidity": (".sol",),
-    "cairo": (".cairo",),
-    "circom": (".circom",),
-    "haskell": (".hs",),
-    "erlang": (".erl",),
-    "masm": (".masm",),
-    "swift": (".swift",),
-    # `.h` files can be C, ObjC, or C++; auto-detect only fires on .m/.mm.
-    # The parser itself still walks .h when invoked with language="objc".
-    "objc": (".m", ".mm"),
-    "kotlin": (".kt", ".kts"),
-    "dart": (".dart",),
-}
-
-_SUPPORTED_LANGUAGES = frozenset(_PARSER_MAP.keys())
-
-
-def _get_parser(language: str) -> LanguageParser:
-    """Lazily import and instantiate a parser for the given language."""
-    entry = _PARSER_MAP.get(language)
-    if entry is None:
-        msg = f"Unsupported language: {language}"
-        raise ValueError(msg)
-    module = importlib.import_module(entry[0])
-    cls = getattr(module, entry[1])
-    return cls()
-
-
-def _resolve_languages(path: str, spec: str) -> list[str]:
-    """Expand a ``language`` argument into a concrete list of languages.
-
-    Accepts:
-    - ``"auto"`` — detect from file extensions under ``path``.
-    - ``"python,rust"`` — comma-separated explicit list.
-    - ``"python"`` — single language (the common case; returned as a
-      single-element list).
-    """
-    if spec == "auto":
-        detected = detect_languages(path)
-        if not detected:
-            msg = f"No supported languages detected under {path}"
-            raise ValueError(msg)
-        return detected
-    names = [name.strip() for name in spec.split(",") if name.strip()] if "," in spec else [spec]
-    for name in names:
-        if name not in _PARSER_MAP:
-            msg = f"Unsupported language: {name}"
-            raise ValueError(msg)
-    return names
-
-
-def _parse_and_merge(path: str, languages: list[str]) -> CodeGraph:
-    """Parse ``path`` with each language's parser and merge into one graph."""
-    if len(languages) == 1:
-        # Preserves pre-polyglot behavior exactly for the common case.
-        return _get_parser(languages[0]).parse_directory(path)
-
-    merged = CodeGraph(
-        language="polyglot",
-        root_path=str(Path(path).resolve()),
-    )
-    for lang in languages:
-        sub = _get_parser(lang).parse_directory(path)
-        merged.merge(sub)
-    # merge() doesn't touch `language`; preserve the polyglot marker.
-    merged.language = "polyglot"
-    return merged
 
 
 def detect_languages(path: str) -> list[str]:
-    """Return the sorted list of languages with at least one file under ``path``.
+    """Detect languages under ``path``.
 
-    Detection walks the directory once, classifies each file by extension,
-    and returns the languages that have at least one match. Order is the
-    order languages are registered in ``_LANGUAGE_EXTENSIONS``, which
-    roughly corresponds to popularity and keeps deterministic behavior.
+    Deprecated: import from ``trailmark.parse`` instead.
     """
-    import os
-
-    root = Path(path)
-    if not root.exists():
-        return []
-
-    ext_to_language: dict[str, str] = {}
-    for lang, exts in _LANGUAGE_EXTENSIONS.items():
-        for ext in exts:
-            # When languages share an extension (none currently do, but
-            # guard against it), the FIRST registration wins.
-            ext_to_language.setdefault(ext, lang)
-
-    found: set[str] = set()
-    for dirpath, _dirs, files in os.walk(root):
-        # Skip common vendor / generated dirs to keep detection snappy.
-        if _should_skip_dir(dirpath):
-            continue
-        for name in files:
-            ext = _file_extension(name)
-            if ext in ext_to_language:
-                found.add(ext_to_language[ext])
-        if len(found) == len(_LANGUAGE_EXTENSIONS):
-            break
-
-    return [lang for lang in _LANGUAGE_EXTENSIONS if lang in found]
-
-
-_SKIP_DIR_NAMES = frozenset(
-    {
-        ".git",
-        ".hg",
-        ".svn",
-        "node_modules",
-        "__pycache__",
-        ".venv",
-        "venv",
-        "env",
-        ".tox",
-        "dist",
-        "build",
-        "target",
-        ".mutants",
-        "mutants",
-    }
-)
-
-
-def _should_skip_dir(dirpath: str) -> bool:
-    """Return True for directories we should exclude from language detection."""
-    parts = Path(dirpath).parts
-    return any(part in _SKIP_DIR_NAMES for part in parts)
-
-
-def _file_extension(name: str) -> str:
-    """Return the lowercase extension including leading dot, or ''."""
-    dot = name.rfind(".")
-    if dot < 0:
-        return ""
-    return name[dot:].lower()
+    return _parse_api.detect_languages(path)
 
 
 class QueryEngine:
@@ -224,8 +52,7 @@ class QueryEngine:
         with. Pass ``detect_entrypoints_=False`` to skip it (e.g. when the
         caller wants to drive detection separately).
         """
-        languages = _resolve_languages(path, language)
-        graph = _parse_and_merge(path, languages)
+        graph = _parse_api.parse_directory(path, language=language)
         if detect_entrypoints_:
             graph.entrypoints.update(detect_entrypoints(graph, path))
         store = GraphStore(graph)

--- a/tests/test_parse_api.py
+++ b/tests/test_parse_api.py
@@ -1,0 +1,106 @@
+"""Tests for the public parse-only API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from trailmark.models.nodes import NodeKind
+from trailmark.parse import (
+    detect_languages,
+    parse_directory,
+    parse_file,
+    supported_languages,
+)
+
+
+class TestSupportedLanguages:
+    def test_includes_common_languages(self) -> None:
+        languages = supported_languages()
+        assert isinstance(languages, tuple)
+        assert "python" in languages
+        assert "rust" in languages
+        assert "typescript" in languages
+
+
+class TestParseFile:
+    def test_parse_file_infers_language_from_extension(self, tmp_path: Path) -> None:
+        path = tmp_path / "auth.py"
+        path.write_text("def login(user: str) -> bool:\n    return True\n")
+
+        graph = parse_file(str(path))
+
+        assert graph.language == "python"
+        assert graph.root_path == str(path)
+        assert "auth:login" in graph.nodes
+        assert graph.nodes["auth:login"].kind == NodeKind.FUNCTION
+
+    def test_parse_file_accepts_explicit_language(self, tmp_path: Path) -> None:
+        path = tmp_path / "lib.rs"
+        path.write_text("fn check() -> bool { true }\n")
+
+        graph = parse_file(str(path), language="rust")
+
+        assert graph.language == "rust"
+        assert "lib:check" in graph.nodes
+
+    def test_parse_file_rejects_unknown_extension_without_language(self, tmp_path: Path) -> None:
+        path = tmp_path / "build.foo"
+        path.write_text("whatever\n")
+
+        with pytest.raises(ValueError, match="Could not infer supported language"):
+            parse_file(str(path))
+
+    def test_parse_file_rejects_multi_language_spec(self, tmp_path: Path) -> None:
+        path = tmp_path / "auth.py"
+        path.write_text("def login():\n    pass\n")
+
+        with pytest.raises(ValueError, match="Single-file parse requires one language"):
+            parse_file(str(path), language="python,rust")
+
+
+class TestParseDirectory:
+    def test_parse_directory_single_language(self, tmp_path: Path) -> None:
+        path = tmp_path / "main.py"
+        path.write_text("def main():\n    pass\n")
+
+        graph = parse_directory(str(tmp_path), language="python")
+
+        assert graph.language == "python"
+        assert "main:main" in graph.nodes
+
+    def test_parse_directory_auto_merges_languages(self, tmp_path: Path) -> None:
+        (tmp_path / "main.py").write_text("def main():\n    pass\n")
+        (tmp_path / "lib.rs").write_text("fn check() {}\n")
+
+        graph = parse_directory(str(tmp_path), language="auto")
+
+        assert graph.language == "polyglot"
+        assert "main:main" in graph.nodes
+        assert "lib:check" in graph.nodes
+
+    def test_detect_languages_is_public(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").write_text("x = 1\n")
+        (tmp_path / "b.rs").write_text("fn x() {}\n")
+
+        assert detect_languages(str(tmp_path)) == ["python", "rust"]
+
+    def test_detect_languages_uses_shared_skip_rules(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text("x = 1\n")
+        vendor = tmp_path / "vendor"
+        vendor.mkdir()
+        (vendor / "dep.go").write_text("package dep\n")
+        cache = tmp_path / ".mypy_cache"
+        cache.mkdir()
+        (cache / "stub.py").write_text("x = 1\n")
+
+        assert detect_languages(str(tmp_path)) == ["python"]
+
+    def test_detect_languages_matches_javascript_parser_extensions(self, tmp_path: Path) -> None:
+        (tmp_path / "module.mjs").write_text("export default {};\n")
+        (tmp_path / "module.cjs").write_text("module.exports = {};\n")
+
+        # The JavaScript parser walks .mjs/.cjs as well as .js/.jsx, so
+        # detect_languages should mirror that and report "javascript".
+        assert detect_languages(str(tmp_path)) == ["javascript"]

--- a/tests/test_polyglot.py
+++ b/tests/test_polyglot.py
@@ -12,7 +12,8 @@ from pathlib import Path
 
 import pytest
 
-from trailmark.query.api import QueryEngine, detect_languages
+from trailmark.parse import detect_languages
+from trailmark.query.api import QueryEngine
 
 
 class TestDetectLanguages:
@@ -40,6 +41,17 @@ class TestDetectLanguages:
         vendor = tmp_path / "node_modules" / "dep"
         vendor.mkdir(parents=True)
         (vendor / "thing.js").write_text("export default {};\n")
+        detected = detect_languages(str(tmp_path))
+        assert detected == ["python"], detected
+
+    def test_skips_parser_excluded_directories(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text("x = 1\n")
+        vendor = tmp_path / "vendor"
+        vendor.mkdir()
+        (vendor / "dep.go").write_text("package dep\n")
+        cache = tmp_path / ".mypy_cache"
+        cache.mkdir()
+        (cache / "stub.py").write_text("x = 1\n")
         detected = detect_languages(str(tmp_path))
         assert detected == ["python"], detected
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -18,8 +18,9 @@ import pytest
 
 import trailmark
 from trailmark.cli import build_parser
+from trailmark.parse import supported_languages
 from trailmark.parsers.javascript.parser import _EXTENSIONS as JS_EXTENSIONS
-from trailmark.query.api import _PARSER_MAP, QueryEngine
+from trailmark.query.api import QueryEngine
 
 
 def _find_repo_root() -> Path:
@@ -110,16 +111,16 @@ class TestSupportedLanguages:
     def test_every_readme_language_has_parser(self, readme_text: str) -> None:
         """Every language in the README table must have a parser registered."""
         readme_languages = _extract_languages_from_readme(readme_text)
-        registered = {_normalize(key) for key in _PARSER_MAP}
+        registered = {_normalize(key) for key in supported_languages()}
         for lang in readme_languages:
             assert _normalize(lang) in registered, (
-                f"README lists `{lang}` but no parser is registered in _PARSER_MAP"
+                f"README lists `{lang}` but no parser is registered"
             )
 
     def test_every_registered_parser_is_documented(self, readme_text: str) -> None:
-        """Every parser in _PARSER_MAP should appear in the README table."""
+        """Every registered parser should appear in the README table."""
         readme_languages = {_normalize(x) for x in _extract_languages_from_readme(readme_text)}
-        for key in _PARSER_MAP:
+        for key in supported_languages():
             assert _normalize(key) in readme_languages, (
                 f"Parser `{key}` is registered but not documented in README"
             )
@@ -220,6 +221,12 @@ class TestCLIDefaults:
         analyze = subparsers_action.choices["analyze"]
         action = _find_option(analyze, "--complexity")
         assert "-c" in action.option_strings
+
+
+class TestParseOnlyAPI:
+    def test_readme_mentions_parse_only_api(self, readme_text: str) -> None:
+        assert "from trailmark.parse import parse_directory, parse_file" in readme_text
+        assert 'graph = parse_file("path/to/file.py")' in readme_text
 
 
 def _read_requires_python(pyproject_data: dict[str, object]) -> str:


### PR DESCRIPTION
Fixes https://github.com/trailofbits/trailmark/issues/22:

Expose a public `trailmark.parse` module for parse-only workflows and
root-package imports. The new API provides `parse_file()`,
`parse_directory()`, `detect_languages()`, and `supported_languages()`,
while `QueryEngine.from_directory()` now delegates to the parse layer
instead of owning parser selection logic directly.

Keep auto-detection aligned with parser behavior by reusing the
shared directory-skip rules from `parsers._common`, narrowing
JavaScript detection to the extensions the parser actually handles,
and adding focused tests for parse-only usage, polyglot detection,
and README coverage.

Update contributor documentation to describe the parse layer in the
architecture overview and to point new parser registration at
`src/trailmark/parse.py`.
