### PR TITLE
[Ignore] Restrict call reachability to CALLS edges

### DIFF
--- a/graph_store.py
+++ b/graph_store.py
@@ -1,0 +1,255 @@
+"""Rustworkx-backed graph storage with query methods."""
+
+from __future__ import annotations
+
+import rustworkx as rx
+
+from trailmark.models.annotations import (
+    Annotation,
+    AnnotationKind,
+    EntrypointTag,
+)
+from trailmark.models.edges import CodeEdge, EdgeKind
+from trailmark.models.graph import CodeGraph
+from trailmark.models.nodes import CodeUnit
+
+
+class GraphStore:
+    """Indexed graph store backed by rustworkx for fast traversals."""
+
+    def __init__(self, graph: CodeGraph) -> None:
+        self._graph = graph
+        self._digraph: rx.PyDiGraph[str, CodeEdge] = rx.PyDiGraph()
+        self._call_digraph: rx.PyDiGraph[str, CodeEdge] = rx.PyDiGraph()
+        self._id_to_idx: dict[str, int] = {}
+        self._idx_to_id: dict[int, str] = {}
+        self._call_id_to_idx: dict[str, int] = {}
+        self._call_idx_to_id: dict[int, str] = {}
+        self._build_index()
+
+    def _build_index(self) -> None:
+        """Populate the rustworkx digraph from the CodeGraph."""
+        for node_id in self._graph.nodes:
+            idx = self._digraph.add_node(node_id)
+            call_idx = self._call_digraph.add_node(node_id)
+            self._id_to_idx[node_id] = idx
+            self._idx_to_id[idx] = node_id
+            self._call_id_to_idx[node_id] = call_idx
+            self._call_idx_to_id[call_idx] = node_id
+
+        for edge in self._graph.edges:
+            src_idx = self._id_to_idx.get(edge.source_id)
+            tgt_idx = self._id_to_idx.get(edge.target_id)
+            if src_idx is not None and tgt_idx is not None:
+                self._digraph.add_edge(src_idx, tgt_idx, edge)
+            if edge.kind == EdgeKind.CALLS:
+                call_src_idx = self._call_id_to_idx.get(edge.source_id)
+                call_tgt_idx = self._call_id_to_idx.get(edge.target_id)
+                if call_src_idx is not None and call_tgt_idx is not None:
+                    self._call_digraph.add_edge(call_src_idx, call_tgt_idx, edge)
+
+    def _idx(self, node_id: str) -> int | None:
+        return self._id_to_idx.get(node_id)
+
+    def _call_idx(self, node_id: str) -> int | None:
+        return self._call_id_to_idx.get(node_id)
+
+    def _node(self, node_id: str) -> CodeUnit | None:
+        return self._graph.nodes.get(node_id)
+
+    def callers_of(self, node_id: str) -> list[CodeUnit]:
+        """Return all nodes that call the given node."""
+        target_idx = self._idx(node_id)
+        if target_idx is None:
+            return []
+        pred_ids: list[str] = self._digraph.predecessors(target_idx)
+        return self._filter_by_edge_kind(
+            pred_ids,
+            node_id,
+            EdgeKind.CALLS,
+            reverse=True,
+        )
+
+    def callees_of(self, node_id: str) -> list[CodeUnit]:
+        """Return all nodes called by the given node."""
+        source_idx = self._idx(node_id)
+        if source_idx is None:
+            return []
+        succ_ids: list[str] = self._digraph.successors(source_idx)
+        return self._filter_by_edge_kind(
+            succ_ids,
+            node_id,
+            EdgeKind.CALLS,
+            reverse=False,
+        )
+
+    def _filter_by_edge_kind(
+        self,
+        neighbor_ids: list[str],
+        anchor_id: str,
+        kind: EdgeKind,
+        *,
+        reverse: bool,
+    ) -> list[CodeUnit]:
+        """Filter neighbors by edge kind between them and anchor."""
+        anchor_idx = self._id_to_idx[anchor_id]
+        result: list[CodeUnit] = []
+        for neighbor_id in neighbor_ids:
+            neighbor_idx = self._id_to_idx.get(neighbor_id)
+            if neighbor_idx is None:
+                continue
+            if reverse:
+                src, tgt = neighbor_idx, anchor_idx
+            else:
+                src, tgt = anchor_idx, neighbor_idx
+            edges = self._digraph.get_all_edge_data(src, tgt)
+            if any(e.kind == kind for e in edges):
+                node = self._node(neighbor_id)
+                if node is not None:
+                    result.append(node)
+        return result
+
+    def paths_between(
+        self,
+        src_id: str,
+        dst_id: str,
+        max_depth: int = 20,
+    ) -> list[list[str]]:
+        """Find all simple paths between two nodes (up to max_depth)."""
+        src_idx = self._call_idx(src_id)
+        dst_idx = self._call_idx(dst_id)
+        if src_idx is None or dst_idx is None:
+            return []
+        raw_paths: list[list[int]] = rx.digraph_all_simple_paths(
+            self._call_digraph,
+            src_idx,
+            dst_idx,
+            cutoff=max_depth,
+        )
+        return [[self._call_idx_to_id[i] for i in path] for path in raw_paths]
+
+    def reachable_from(self, node_id: str) -> set[str]:
+        """Return all node IDs reachable from the given node."""
+        idx = self._call_idx(node_id)
+        if idx is None:
+            return set()
+        descendants = rx.descendants(self._call_digraph, idx)
+        return {self._call_idx_to_id[i] for i in descendants}
+
+    def nodes_with_annotation(
+        self,
+        kind: AnnotationKind,
+    ) -> list[CodeUnit]:
+        """Return all nodes that have an annotation of the given kind."""
+        result: list[CodeUnit] = []
+        for node_id, anns in self._graph.annotations.items():
+            for ann in anns:
+                if ann.kind == kind:
+                    node = self._node(node_id)
+                    if node is not None:
+                        result.append(node)
+                    break
+        return result
+
+    def all_entrypoints(self) -> list[tuple[str, EntrypointTag]]:
+        """Return all entrypoint-tagged nodes."""
+        return list(self._graph.entrypoints.items())
+
+    def entrypoint_paths_to(
+        self,
+        node_id: str,
+        max_depth: int = 20,
+    ) -> list[list[str]]:
+        """Find all paths from any entrypoint to the given node."""
+        all_paths: list[list[str]] = []
+        for ep_id in self._graph.entrypoints:
+            paths = self.paths_between(ep_id, node_id, max_depth)
+            all_paths.extend(paths)
+        return all_paths
+
+    def nodes_by_complexity(
+        self,
+        min_complexity: int,
+    ) -> list[CodeUnit]:
+        """Return nodes with cyclomatic complexity >= threshold."""
+        return [
+            node
+            for node in self._graph.nodes.values()
+            if node.cyclomatic_complexity is not None
+            and node.cyclomatic_complexity >= min_complexity
+        ]
+
+    def add_annotation(
+        self,
+        node_id: str,
+        annotation: Annotation,
+    ) -> bool:
+        """Add an annotation to an existing node.
+
+        Returns False if the node does not exist.
+        """
+        if self._node(node_id) is None:
+            return False
+        self._graph.add_annotation(node_id, annotation)
+        return True
+
+    def annotations_for(self, node_id: str) -> list[Annotation]:
+        """Return all annotations for a node, or empty list."""
+        return list(self._graph.annotations.get(node_id, []))
+
+    def clear_annotations(
+        self,
+        node_id: str,
+        kind: AnnotationKind | None = None,
+    ) -> bool:
+        """Clear annotations for a node.
+
+        Returns False if the node does not exist.
+        """
+        if self._node(node_id) is None:
+            return False
+        self._graph.clear_annotations(node_id, kind)
+        return True
+
+    def find_node(self, name: str) -> CodeUnit | None:
+        """Find a node by exact ID, name match, or qualified suffix.
+
+        Lookup precedence:
+        1. Exact node ID match
+        2. Exact name field match
+        3. ID ending with ``:name`` (module:function)
+        4. ID ending with ``.name`` (class.method)
+        """
+        if name in self._graph.nodes:
+            return self._graph.nodes[name]
+        for node_id, node in self._graph.nodes.items():
+            if node.name == name or node_id.endswith(f":{name}"):
+                return node
+            if node_id.endswith(f".{name}"):
+                return node
+        return None
+
+    def find_node_id(self, name: str) -> str | None:
+        """Find a node ID by exact ID or name substring."""
+        node = self.find_node(name)
+        return node.id if node is not None else None
+
+    def add_subgraph(self, name: str, node_ids: set[str]) -> None:
+        """Register a named subgraph (set of node IDs)."""
+        self._graph.subgraphs[name] = node_ids
+
+    def subgraph(self, name: str) -> set[str]:
+        """Return the node IDs in a named subgraph, or empty set."""
+        return self._graph.subgraphs.get(name, set())
+
+    def all_subgraphs(self) -> dict[str, set[str]]:
+        """Return all named subgraphs."""
+        return dict(self._graph.subgraphs)
+
+    def ancestors_of(self, node_id: str) -> set[str]:
+        """Return all node IDs that can reach the given node."""
+        idx = self._call_idx(node_id)
+        if idx is None:
+            return set()
+        ancestor_indices = rx.ancestors(self._call_digraph, idx)
+        return {self._call_idx_to_id[i] for i in ancestor_indices}

--- a/preanalysis.py
+++ b/preanalysis.py
@@ -1,0 +1,318 @@
+"""Pre-analysis passes that enrich code graphs before downstream skills.
+
+Runs four passes over the graph:
+1. Blast radius estimation — how many nodes are affected per function
+2. Entry point enumeration — systematic entrypoint + reachability mapping
+3. Privilege boundary crossing — where trust levels change across calls
+4. Taint propagation — untrusted data flow through the call graph
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import rustworkx as rx
+
+from trailmark.models.annotations import (
+    Annotation,
+    AnnotationKind,
+    TrustLevel,
+)
+from trailmark.models.edges import EdgeKind
+from trailmark.models.graph import CodeGraph
+from trailmark.storage.graph_store import GraphStore
+
+_BLAST_RADIUS_THRESHOLD = 10
+_PREANALYSIS_SOURCE = "preanalysis"
+_PREANALYSIS_SUBGRAPHS = frozenset(
+    {
+        "high_blast_radius",
+        "entrypoints",
+        "entrypoint_reachable",
+        "privilege_boundary",
+        "tainted",
+    }
+)
+
+
+def _clear_prior_preanalysis(store: GraphStore) -> None:
+    """Remove annotations and subgraphs from a previous preanalysis run."""
+    graph = store._graph  # noqa: SLF001
+    for node_id in list(graph.annotations):
+        graph.annotations[node_id] = [
+            a for a in graph.annotations[node_id] if a.source != _PREANALYSIS_SOURCE
+        ]
+        if not graph.annotations[node_id]:
+            del graph.annotations[node_id]
+    for name in list(graph.subgraphs):
+        if name in _PREANALYSIS_SUBGRAPHS or name.startswith("entrypoints:"):
+            del graph.subgraphs[name]
+
+
+def run_preanalysis(store: GraphStore) -> dict[str, Any]:
+    """Run all pre-analysis passes and return a summary.
+
+    Mutates the graph by adding annotations and subgraphs.
+    Returns a dict summarising what each pass found.
+
+    Safe to call multiple times: clears prior preanalysis
+    annotations before recomputing.
+    """
+    _clear_prior_preanalysis(store)
+    blast = _compute_blast_radius(store)
+    entry = _enumerate_entrypoints(store)
+    priv = _detect_privilege_boundaries(store)
+    taint = _propagate_taint(store)
+    return {
+        "blast_radius": blast,
+        "entrypoints": entry,
+        "privilege_boundaries": priv,
+        "taint_propagation": taint,
+    }
+
+
+def _compute_blast_radius(store: GraphStore) -> dict[str, Any]:
+    """Annotate each node with its downstream blast radius.
+
+    Blast radius = number of nodes reachable via call edges.
+    Nodes above the threshold are collected in a subgraph.
+    """
+    graph = store._graph  # noqa: SLF001
+    digraph = store._call_digraph  # noqa: SLF001
+    id_to_idx = store._call_id_to_idx  # noqa: SLF001
+    idx_to_id = store._call_idx_to_id  # noqa: SLF001
+
+    high_blast: set[str] = set()
+    max_radius = 0
+    annotated = 0
+
+    for node_id in graph.nodes:
+        idx = id_to_idx.get(node_id)
+        if idx is None:
+            continue
+        descendants = rx.descendants(digraph, idx)
+        downstream = len(descendants)
+        ancestors = rx.ancestors(digraph, idx)
+        upstream = len(ancestors)
+
+        critical = _top_critical_descendants(
+            descendants,
+            idx_to_id,
+            graph,
+        )
+        desc = f"{downstream} downstream, {upstream} upstream"
+        if critical:
+            desc += f"; critical: {', '.join(critical)}"
+
+        ann = Annotation(
+            kind=AnnotationKind.BLAST_RADIUS,
+            description=desc,
+            source="preanalysis",
+        )
+        graph.add_annotation(node_id, ann)
+        annotated += 1
+
+        if downstream >= _BLAST_RADIUS_THRESHOLD:
+            high_blast.add(node_id)
+        max_radius = max(max_radius, downstream)
+
+    store.add_subgraph("high_blast_radius", high_blast)
+    return {
+        "annotated_nodes": annotated,
+        "high_blast_count": len(high_blast),
+        "max_radius": max_radius,
+        "threshold": _BLAST_RADIUS_THRESHOLD,
+    }
+
+
+def _top_critical_descendants(
+    descendants: set[int],
+    idx_to_id: dict[int, str],
+    graph: CodeGraph,
+    limit: int = 5,
+) -> list[str]:
+    """Pick the highest-complexity descendants as critical."""
+    scored: list[tuple[int, str]] = []
+    for d_idx in descendants:
+        d_id = idx_to_id.get(d_idx)
+        if d_id is None:
+            continue
+        node = graph.nodes.get(d_id)
+        if node is None:
+            continue
+        cc = node.cyclomatic_complexity or 0
+        if cc > 0:
+            scored.append((cc, d_id))
+    scored.sort(reverse=True)
+    return [name for _, name in scored[:limit]]
+
+
+def _enumerate_entrypoints(store: GraphStore) -> dict[str, Any]:
+    """Build subgraphs for entrypoints and their reachable nodes."""
+    graph = store._graph  # noqa: SLF001
+
+    ep_ids: set[str] = set()
+    reachable_all: set[str] = set()
+    by_trust: dict[str, set[str]] = {}
+
+    for ep_id, tag in graph.entrypoints.items():
+        ep_ids.add(ep_id)
+        trust_key = tag.trust_level.value
+        by_trust.setdefault(trust_key, set()).add(ep_id)
+
+        reachable = store.reachable_from(ep_id)
+        reachable_all.update(reachable)
+        reachable_all.add(ep_id)
+
+    store.add_subgraph("entrypoints", ep_ids)
+    store.add_subgraph("entrypoint_reachable", reachable_all)
+    for trust_key, ids in by_trust.items():
+        store.add_subgraph(f"entrypoints:{trust_key}", ids)
+
+    return {
+        "total_entrypoints": len(ep_ids),
+        "reachable_nodes": len(reachable_all),
+        "by_trust_level": {k: len(v) for k, v in by_trust.items()},
+    }
+
+
+def _detect_privilege_boundaries(
+    store: GraphStore,
+) -> dict[str, Any]:
+    """Find nodes where trust levels change across call edges.
+
+    A privilege boundary exists where a node reachable from an
+    untrusted entrypoint calls into a node reachable only from
+    trusted entrypoints (or not tagged at all).
+    """
+    graph = store._graph  # noqa: SLF001
+
+    untrusted_reachable = _reachable_from_trust(
+        store,
+        TrustLevel.UNTRUSTED_EXTERNAL,
+    )
+    semi_trusted_reachable = _reachable_from_trust(
+        store,
+        TrustLevel.SEMI_TRUSTED_EXTERNAL,
+    )
+    trusted_reachable = _reachable_from_trust(
+        store,
+        TrustLevel.TRUSTED_INTERNAL,
+    )
+
+    boundary_nodes: set[str] = set()
+
+    for edge in graph.edges:
+        if edge.kind != EdgeKind.CALLS:
+            continue
+        src, tgt = edge.source_id, edge.target_id
+        src_trust = _node_trust_set(
+            src,
+            untrusted_reachable,
+            semi_trusted_reachable,
+            trusted_reachable,
+        )
+        tgt_trust = _node_trust_set(
+            tgt,
+            untrusted_reachable,
+            semi_trusted_reachable,
+            trusted_reachable,
+        )
+        if src_trust != tgt_trust and src_trust and tgt_trust:
+            boundary_nodes.add(src)
+            boundary_nodes.add(tgt)
+            for node_id in (src, tgt):
+                ann = Annotation(
+                    kind=AnnotationKind.PRIVILEGE_BOUNDARY,
+                    description=(
+                        f"trust transition across call: "
+                        f"{_trust_label(src_trust)}"
+                        f" -> {_trust_label(tgt_trust)}"
+                    ),
+                    source="preanalysis",
+                )
+                graph.add_annotation(node_id, ann)
+
+    store.add_subgraph("privilege_boundary", boundary_nodes)
+    return {"boundary_nodes": len(boundary_nodes)}
+
+
+def _reachable_from_trust(
+    store: GraphStore,
+    trust: TrustLevel,
+) -> set[str]:
+    """Return all nodes reachable from entrypoints at a trust level."""
+    graph = store._graph  # noqa: SLF001
+    result: set[str] = set()
+    for ep_id, tag in graph.entrypoints.items():
+        if tag.trust_level == trust:
+            result.add(ep_id)
+            result.update(store.reachable_from(ep_id))
+    return result
+
+
+def _node_trust_set(
+    node_id: str,
+    untrusted: set[str],
+    semi_trusted: set[str],
+    trusted: set[str],
+) -> frozenset[str]:
+    """Return the set of trust levels that can reach a node."""
+    levels: set[str] = set()
+    if node_id in untrusted:
+        levels.add("untrusted_external")
+    if node_id in semi_trusted:
+        levels.add("semi_trusted_external")
+    if node_id in trusted:
+        levels.add("trusted_internal")
+    return frozenset(levels)
+
+
+def _trust_label(levels: frozenset[str]) -> str:
+    if not levels:
+        return "none"
+    return "+".join(sorted(levels))
+
+
+def _propagate_taint(store: GraphStore) -> dict[str, Any]:
+    """Propagate taint from untrusted entrypoints through calls.
+
+    Marks all reachable nodes as tainted and annotates each with
+    the entrypoint source that taints it.
+    """
+    graph = store._graph  # noqa: SLF001
+
+    tainted_all: set[str] = set()
+    taint_sources: dict[str, list[str]] = {}
+
+    for ep_id, tag in graph.entrypoints.items():
+        if tag.trust_level == TrustLevel.TRUSTED_INTERNAL:
+            continue
+        reachable = store.reachable_from(ep_id)
+        reachable.add(ep_id)
+        tainted_all.update(reachable)
+
+        for node_id in reachable:
+            taint_sources.setdefault(node_id, []).append(ep_id)
+
+    for node_id, sources in taint_sources.items():
+        unique = sorted(set(sources))
+        desc = f"tainted via: {', '.join(unique)}"
+        ann = Annotation(
+            kind=AnnotationKind.TAINT_PROPAGATION,
+            description=desc,
+            source="preanalysis",
+        )
+        graph.add_annotation(node_id, ann)
+
+    store.add_subgraph("tainted", tainted_all)
+    return {
+        "tainted_nodes": len(tainted_all),
+        "taint_sources": len(
+            [
+                ep_id
+                for ep_id, tag in graph.entrypoints.items()
+                if tag.trust_level != TrustLevel.TRUSTED_INTERNAL
+            ],
+        ),
+    }

--- a/test_hidden_apis.py
+++ b/test_hidden_apis.py
@@ -1,0 +1,121 @@
+"""Tests for the newly exposed QueryEngine methods.
+
+Covers ``ancestors_of``, ``reachable_from``, ``entrypoint_paths_to``,
+``nodes_with_annotation``, and ``functions_that_raise`` — methods that
+existed in ``GraphStore`` but had no public-facing analogue.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from trailmark.models.annotations import AnnotationKind
+from trailmark.query.api import QueryEngine
+
+
+class TestAncestorsOf:
+    def test_direct_caller_is_ancestor(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text(
+            "def sink():\n    pass\n\ndef caller():\n    sink()\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path))
+        ancestors = engine.ancestors_of("sink")
+        names = {a["name"] for a in ancestors}
+        assert "caller" in names
+
+    def test_transitive_ancestor_surfaces(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text(
+            "def sink():\n    pass\ndef middle():\n    sink()\ndef top():\n    middle()\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path))
+        names = {a["name"] for a in engine.ancestors_of("sink")}
+        assert {"middle", "top"}.issubset(names)
+
+    def test_unknown_node_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text("def only():\n    pass\n")
+        engine = QueryEngine.from_directory(str(tmp_path))
+        assert engine.ancestors_of("does_not_exist") == []
+
+    def test_node_with_no_callers_has_no_call_ancestors(self, tmp_path: Path) -> None:
+        """A function with no callers has no call ancestors."""
+        (tmp_path / "app.py").write_text("def solo():\n    pass\n")
+        engine = QueryEngine.from_directory(str(tmp_path))
+        assert engine.ancestors_of("solo") == []
+
+
+class TestReachableFrom:
+    def test_direct_callee_is_reachable(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text(
+            "def a():\n    b()\n\ndef b():\n    pass\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path))
+        names = {n["name"] for n in engine.reachable_from("a")}
+        assert "b" in names
+
+    def test_transitive_reachability(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text(
+            "def a():\n    b()\ndef b():\n    c()\ndef c():\n    pass\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path))
+        names = {n["name"] for n in engine.reachable_from("a")}
+        assert {"b", "c"}.issubset(names)
+
+
+class TestEntrypointPathsTo:
+    def test_path_from_entrypoint_to_sink(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text(
+            "def main():\n    validate()\n"
+            "def validate():\n    sensitive()\n"
+            "def sensitive():\n    pass\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path))
+        paths = engine.entrypoint_paths_to("sensitive")
+        assert paths, "Expected at least one entrypoint->sink path"
+        assert any(p[0] == "app:main" and p[-1] == "app:sensitive" for p in paths), paths
+
+    def test_unreachable_sink_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text(
+            "def main():\n    pass\n\ndef orphan():\n    pass\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path))
+        assert engine.entrypoint_paths_to("orphan") == []
+
+
+class TestNodesWithAnnotation:
+    def test_manual_annotation_retrievable(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text("def risky():\n    pass\n")
+        engine = QueryEngine.from_directory(str(tmp_path))
+        engine.annotate(
+            "risky",
+            AnnotationKind.FINDING,
+            "manually flagged",
+            source="test",
+        )
+        finds = engine.nodes_with_annotation(AnnotationKind.FINDING)
+        names = {n["name"] for n in finds}
+        assert "risky" in names
+
+    def test_empty_when_no_annotations(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text("def ok():\n    pass\n")
+        engine = QueryEngine.from_directory(str(tmp_path))
+        assert engine.nodes_with_annotation(AnnotationKind.FINDING) == []
+
+
+class TestFunctionsThatRaise:
+    def test_raises_detected_from_python_source(self, tmp_path: Path) -> None:
+        """Python parser populates exception_types from `raise` statements."""
+        (tmp_path / "app.py").write_text(
+            "def bad():\n    raise ValueError('nope')\n\ndef good():\n    return 1\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path))
+        raisers = engine.functions_that_raise("ValueError")
+        names = {n["name"] for n in raisers}
+        assert "bad" in names
+        assert "good" not in names
+
+    def test_unknown_exception_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text(
+            "def bad():\n    raise ValueError('nope')\n",
+        )
+        engine = QueryEngine.from_directory(str(tmp_path))
+        assert engine.functions_that_raise("KeyError") == []

--- a/test_preanalysis.py
+++ b/test_preanalysis.py
@@ -1,0 +1,368 @@
+"""Tests for the pre-analysis passes."""
+
+from __future__ import annotations
+
+from trailmark.models import (
+    AnnotationKind,
+    CodeEdge,
+    CodeGraph,
+    CodeUnit,
+    EdgeKind,
+    EntrypointKind,
+    EntrypointTag,
+    NodeKind,
+    SourceLocation,
+    TrustLevel,
+)
+from trailmark.query.api import QueryEngine
+
+_LOC = SourceLocation(file_path="test.py", start_line=1, end_line=10)
+
+
+def _node(
+    node_id: str,
+    name: str,
+    complexity: int | None = None,
+    kind: NodeKind = NodeKind.FUNCTION,
+) -> CodeUnit:
+    return CodeUnit(
+        id=node_id,
+        name=name,
+        kind=kind,
+        location=_LOC,
+        cyclomatic_complexity=complexity,
+    )
+
+
+def _build_chain_graph() -> QueryEngine:
+    """Build: ep_untrusted -> handler -> db_query -> logger.
+
+    ep_untrusted is an untrusted entrypoint.
+    """
+    nodes = {
+        "ep_untrusted": _node("ep_untrusted", "ep_untrusted", 2),
+        "handler": _node("handler", "handler", 12),
+        "db_query": _node("db_query", "db_query", 8),
+        "logger": _node("logger", "logger", 1),
+    }
+    edges = [
+        CodeEdge("ep_untrusted", "handler", EdgeKind.CALLS),
+        CodeEdge("handler", "db_query", EdgeKind.CALLS),
+        CodeEdge("handler", "logger", EdgeKind.CALLS),
+    ]
+    graph = CodeGraph(
+        nodes=nodes,
+        edges=edges,
+        entrypoints={
+            "ep_untrusted": EntrypointTag(
+                kind=EntrypointKind.USER_INPUT,
+                trust_level=TrustLevel.UNTRUSTED_EXTERNAL,
+            ),
+        },
+    )
+    return QueryEngine.from_graph(graph)
+
+
+def _build_mixed_trust_graph() -> QueryEngine:
+    """Build a graph with both trusted and untrusted entrypoints.
+
+    ep_untrusted -> shared_handler -> db_write
+    ep_trusted   -> shared_handler -> db_write
+    """
+    nodes = {
+        "ep_untrusted": _node("ep_untrusted", "ep_untrusted", 2),
+        "ep_trusted": _node("ep_trusted", "ep_trusted", 1),
+        "shared_handler": _node("shared_handler", "shared_handler", 6),
+        "db_write": _node("db_write", "db_write", 3),
+    }
+    edges = [
+        CodeEdge("ep_untrusted", "shared_handler", EdgeKind.CALLS),
+        CodeEdge("ep_trusted", "shared_handler", EdgeKind.CALLS),
+        CodeEdge("shared_handler", "db_write", EdgeKind.CALLS),
+    ]
+    graph = CodeGraph(
+        nodes=nodes,
+        edges=edges,
+        entrypoints={
+            "ep_untrusted": EntrypointTag(
+                kind=EntrypointKind.USER_INPUT,
+                trust_level=TrustLevel.UNTRUSTED_EXTERNAL,
+            ),
+            "ep_trusted": EntrypointTag(
+                kind=EntrypointKind.API,
+                trust_level=TrustLevel.TRUSTED_INTERNAL,
+            ),
+        },
+    )
+    return QueryEngine.from_graph(graph)
+
+
+def _build_no_entrypoints_graph() -> QueryEngine:
+    """Build a simple graph with no entrypoints."""
+    nodes = {
+        "a": _node("a", "a", 3),
+        "b": _node("b", "b", 5),
+    }
+    edges = [CodeEdge("a", "b", EdgeKind.CALLS)]
+    graph = CodeGraph(nodes=nodes, edges=edges)
+    return QueryEngine.from_graph(graph)
+
+
+class TestPreanalysisReturnsSummary:
+    def test_returns_all_keys(self) -> None:
+        engine = _build_chain_graph()
+        result = engine.preanalysis()
+        assert "blast_radius" in result
+        assert "entrypoints" in result
+        assert "privilege_boundaries" in result
+        assert "taint_propagation" in result
+
+
+class TestBlastRadius:
+    def test_annotates_all_nodes(self) -> None:
+        engine = _build_chain_graph()
+        result = engine.preanalysis()
+        assert result["blast_radius"]["annotated_nodes"] == 4
+
+    def test_high_blast_radius_subgraph(self) -> None:
+        """Nodes with many descendants should be in subgraph."""
+        # Build a wider graph so ep has >= 10 descendants
+        nodes = {"ep": _node("ep", "ep", 1)}
+        edges = []
+        for i in range(12):
+            nid = f"f{i}"
+            nodes[nid] = _node(nid, nid, 1)
+            edges.append(CodeEdge("ep", nid, EdgeKind.CALLS))
+        graph = CodeGraph(
+            nodes=nodes,
+            edges=edges,
+            entrypoints={
+                "ep": EntrypointTag(
+                    kind=EntrypointKind.USER_INPUT,
+                    trust_level=TrustLevel.UNTRUSTED_EXTERNAL,
+                ),
+            },
+        )
+        engine = QueryEngine.from_graph(graph)
+        engine.preanalysis()
+        high = engine.subgraph("high_blast_radius")
+        ep_ids = {n["id"] for n in high}
+        assert "ep" in ep_ids
+
+    def test_max_radius(self) -> None:
+        engine = _build_chain_graph()
+        result = engine.preanalysis()
+        # ep_untrusted -> handler -> (db_query, logger) = 3 descendants
+        assert result["blast_radius"]["max_radius"] == 3
+
+    def test_blast_radius_annotation_content(self) -> None:
+        engine = _build_chain_graph()
+        engine.preanalysis()
+        anns = engine.annotations_of(
+            "ep_untrusted",
+            kind=AnnotationKind.BLAST_RADIUS,
+        )
+        assert len(anns) == 1
+        assert "downstream" in anns[0]["description"]
+        assert "upstream" in anns[0]["description"]
+
+    def test_critical_descendants_in_annotation(self) -> None:
+        engine = _build_chain_graph()
+        engine.preanalysis()
+        anns = engine.annotations_of(
+            "ep_untrusted",
+            kind=AnnotationKind.BLAST_RADIUS,
+        )
+        # handler has CC=12, should appear as critical
+        assert "handler" in anns[0]["description"]
+
+    def test_blast_radius_ignores_non_call_edges(self) -> None:
+        nodes = {
+            "mod": _node("mod", "mod", kind=NodeKind.MODULE),
+            "f": _node("f", "f", 7),
+        }
+        graph = CodeGraph(
+            nodes=nodes,
+            edges=[CodeEdge("mod", "f", EdgeKind.CONTAINS)],
+        )
+        engine = QueryEngine.from_graph(graph)
+        result = engine.preanalysis()
+
+        assert result["blast_radius"]["max_radius"] == 0
+        anns = engine.annotations_of("mod", kind=AnnotationKind.BLAST_RADIUS)
+        assert anns[0]["description"].startswith("0 downstream, 0 upstream")
+
+
+class TestEntrypointEnumeration:
+    def test_entrypoints_subgraph(self) -> None:
+        engine = _build_chain_graph()
+        engine.preanalysis()
+        ep_nodes = engine.subgraph("entrypoints")
+        ep_ids = {n["id"] for n in ep_nodes}
+        assert ep_ids == {"ep_untrusted"}
+
+    def test_reachable_subgraph(self) -> None:
+        engine = _build_chain_graph()
+        engine.preanalysis()
+        reachable = engine.subgraph("entrypoint_reachable")
+        reachable_ids = {n["id"] for n in reachable}
+        assert "handler" in reachable_ids
+        assert "db_query" in reachable_ids
+        assert "ep_untrusted" in reachable_ids
+
+    def test_by_trust_level_subgraph(self) -> None:
+        engine = _build_mixed_trust_graph()
+        engine.preanalysis()
+        untrusted = engine.subgraph("entrypoints:untrusted_external")
+        assert len(untrusted) == 1
+        assert untrusted[0]["id"] == "ep_untrusted"
+
+    def test_summary_counts(self) -> None:
+        engine = _build_mixed_trust_graph()
+        result = engine.preanalysis()
+        ep = result["entrypoints"]
+        assert ep["total_entrypoints"] == 2
+        assert ep["reachable_nodes"] >= 4
+
+    def test_no_entrypoints(self) -> None:
+        engine = _build_no_entrypoints_graph()
+        result = engine.preanalysis()
+        assert result["entrypoints"]["total_entrypoints"] == 0
+        assert result["entrypoints"]["reachable_nodes"] == 0
+
+
+class TestPrivilegeBoundary:
+    def test_detects_boundary_in_mixed_trust(self) -> None:
+        engine = _build_mixed_trust_graph()
+        result = engine.preanalysis()
+        assert result["privilege_boundaries"]["boundary_nodes"] > 0
+
+    def test_boundary_subgraph_populated(self) -> None:
+        engine = _build_mixed_trust_graph()
+        engine.preanalysis()
+        boundary = engine.subgraph("privilege_boundary")
+        boundary_ids = {n["id"] for n in boundary}
+        # shared_handler and db_write are reachable from both
+        # trust levels, so they should be at the boundary
+        assert len(boundary_ids) > 0
+
+    def test_no_boundary_with_single_trust(self) -> None:
+        engine = _build_chain_graph()
+        result = engine.preanalysis()
+        assert result["privilege_boundaries"]["boundary_nodes"] == 0
+
+    def test_boundary_annotation_content(self) -> None:
+        engine = _build_mixed_trust_graph()
+        engine.preanalysis()
+        boundary = engine.subgraph("privilege_boundary")
+        if boundary:
+            node_id = boundary[0]["id"]
+            anns = engine.annotations_of(
+                node_id,
+                kind=AnnotationKind.PRIVILEGE_BOUNDARY,
+            )
+            assert len(anns) >= 1
+            assert "trust transition" in anns[0]["description"]
+
+
+class TestTaintPropagation:
+    def test_tainted_subgraph(self) -> None:
+        engine = _build_chain_graph()
+        engine.preanalysis()
+        tainted = engine.subgraph("tainted")
+        tainted_ids = {n["id"] for n in tainted}
+        assert "ep_untrusted" in tainted_ids
+        assert "handler" in tainted_ids
+        assert "db_query" in tainted_ids
+
+    def test_taint_annotation_content(self) -> None:
+        engine = _build_chain_graph()
+        engine.preanalysis()
+        anns = engine.annotations_of(
+            "handler",
+            kind=AnnotationKind.TAINT_PROPAGATION,
+        )
+        assert len(anns) == 1
+        assert "ep_untrusted" in anns[0]["description"]
+
+    def test_trusted_entrypoint_not_taint_source(self) -> None:
+        """Trusted entrypoints should not propagate taint."""
+        nodes = {
+            "ep_trusted": _node("ep_trusted", "ep_trusted", 1),
+            "internal": _node("internal", "internal", 2),
+        }
+        edges = [
+            CodeEdge("ep_trusted", "internal", EdgeKind.CALLS),
+        ]
+        graph = CodeGraph(
+            nodes=nodes,
+            edges=edges,
+            entrypoints={
+                "ep_trusted": EntrypointTag(
+                    kind=EntrypointKind.API,
+                    trust_level=TrustLevel.TRUSTED_INTERNAL,
+                ),
+            },
+        )
+        engine = QueryEngine.from_graph(graph)
+        result = engine.preanalysis()
+        assert result["taint_propagation"]["tainted_nodes"] == 0
+
+    def test_semi_trusted_does_taint(self) -> None:
+        """Semi-trusted entrypoints should propagate taint."""
+        nodes = {
+            "ep_semi": _node("ep_semi", "ep_semi", 1),
+            "target": _node("target", "target", 2),
+        }
+        edges = [
+            CodeEdge("ep_semi", "target", EdgeKind.CALLS),
+        ]
+        graph = CodeGraph(
+            nodes=nodes,
+            edges=edges,
+            entrypoints={
+                "ep_semi": EntrypointTag(
+                    kind=EntrypointKind.THIRD_PARTY,
+                    trust_level=TrustLevel.SEMI_TRUSTED_EXTERNAL,
+                ),
+            },
+        )
+        engine = QueryEngine.from_graph(graph)
+        result = engine.preanalysis()
+        assert result["taint_propagation"]["tainted_nodes"] == 2
+
+    def test_no_entrypoints_no_taint(self) -> None:
+        engine = _build_no_entrypoints_graph()
+        result = engine.preanalysis()
+        assert result["taint_propagation"]["tainted_nodes"] == 0
+
+    def test_taint_source_count(self) -> None:
+        engine = _build_mixed_trust_graph()
+        result = engine.preanalysis()
+        # Only ep_untrusted is a taint source (trusted is excluded)
+        assert result["taint_propagation"]["taint_sources"] == 1
+
+
+class TestSubgraphAPI:
+    def test_subgraph_names_populated(self) -> None:
+        engine = _build_chain_graph()
+        engine.preanalysis()
+        names = engine.subgraph_names()
+        assert "entrypoints" in names
+        assert "tainted" in names
+        assert "high_blast_radius" in names
+
+    def test_subgraph_empty_name(self) -> None:
+        engine = _build_chain_graph()
+        result = engine.subgraph("nonexistent")
+        assert result == []
+
+    def test_subgraphs_in_json(self) -> None:
+        """Subgraphs should appear in JSON export."""
+        import json
+
+        engine = _build_chain_graph()
+        engine.preanalysis()
+        data = json.loads(engine.to_json())
+        assert "subgraphs" in data
+        assert "tainted" in data["subgraphs"]

--- a/test_storage.py
+++ b/test_storage.py
@@ -1,0 +1,627 @@
+"""Tests for the rustworkx-backed graph store."""
+
+from __future__ import annotations
+
+from trailmark.models import (
+    Annotation,
+    AnnotationKind,
+    CodeEdge,
+    CodeGraph,
+    CodeUnit,
+    EdgeKind,
+    EntrypointKind,
+    EntrypointTag,
+    NodeKind,
+    SourceLocation,
+    TrustLevel,
+)
+from trailmark.storage.graph_store import GraphStore
+
+_LOC = SourceLocation(file_path="test.py", start_line=1, end_line=10)
+
+
+def _make_node(
+    node_id: str,
+    name: str,
+    complexity: int | None = None,
+) -> CodeUnit:
+    return CodeUnit(
+        id=node_id,
+        name=name,
+        kind=NodeKind.FUNCTION,
+        location=_LOC,
+        cyclomatic_complexity=complexity,
+    )
+
+
+def _build_graph() -> tuple[CodeGraph, GraphStore]:
+    """Build a test graph: A -> B -> C, A -> D."""
+    nodes = {
+        "a": _make_node("a", "a"),
+        "b": _make_node("b", "b"),
+        "c": _make_node("c", "c"),
+        "d": _make_node("d", "d"),
+    }
+    edges = [
+        CodeEdge(source_id="a", target_id="b", kind=EdgeKind.CALLS),
+        CodeEdge(source_id="b", target_id="c", kind=EdgeKind.CALLS),
+        CodeEdge(source_id="a", target_id="d", kind=EdgeKind.CALLS),
+    ]
+    graph = CodeGraph(nodes=nodes, edges=edges)
+    return graph, GraphStore(graph)
+
+
+def _build_contains_bridge_graph() -> tuple[CodeGraph, GraphStore]:
+    """Build a graph where CONTAINS would be a false call bridge."""
+    nodes = {
+        "mod": _make_node("mod", "mod"),
+        "a": _make_node("a", "a"),
+        "b": _make_node("b", "b"),
+    }
+    edges = [
+        CodeEdge(source_id="mod", target_id="a", kind=EdgeKind.CONTAINS),
+        CodeEdge(source_id="a", target_id="b", kind=EdgeKind.CALLS),
+    ]
+    graph = CodeGraph(nodes=nodes, edges=edges)
+    return graph, GraphStore(graph)
+
+
+class TestGraphStoreCallers:
+    def test_callers_of_b(self) -> None:
+        _, store = _build_graph()
+        callers = store.callers_of("b")
+        assert len(callers) == 1
+        assert callers[0].id == "a"
+        assert callers[0].name == "a"
+
+    def test_callers_of_c(self) -> None:
+        _, store = _build_graph()
+        callers = store.callers_of("c")
+        assert len(callers) == 1
+        assert callers[0].id == "b"
+
+    def test_callers_of_root(self) -> None:
+        _, store = _build_graph()
+        callers = store.callers_of("a")
+        assert len(callers) == 0
+
+    def test_callers_of_nonexistent(self) -> None:
+        _, store = _build_graph()
+        assert store.callers_of("zzz") == []
+
+
+class TestGraphStoreCallees:
+    def test_callees_of_a(self) -> None:
+        _, store = _build_graph()
+        callees = store.callees_of("a")
+        ids = {c.id for c in callees}
+        assert ids == {"b", "d"}
+        assert len(callees) == 2
+
+    def test_callees_of_b(self) -> None:
+        _, store = _build_graph()
+        callees = store.callees_of("b")
+        assert len(callees) == 1
+        assert callees[0].id == "c"
+
+    def test_callees_of_leaf(self) -> None:
+        _, store = _build_graph()
+        assert store.callees_of("c") == []
+
+    def test_callees_of_nonexistent(self) -> None:
+        _, store = _build_graph()
+        assert store.callees_of("zzz") == []
+
+    def test_callees_differ_from_callers(self) -> None:
+        """callees_of and callers_of must return different results for middle node."""
+        _, store = _build_graph()
+        callees = store.callees_of("b")
+        callers = store.callers_of("b")
+        callee_ids = {c.id for c in callees}
+        caller_ids = {c.id for c in callers}
+        assert callee_ids == {"c"}
+        assert caller_ids == {"a"}
+        assert callee_ids != caller_ids
+
+    def test_callees_only_calls_edges(self) -> None:
+        """Only CALLS edges should be returned, not CONTAINS."""
+        nodes = {
+            "mod": _make_node("mod", "mod"),
+            "f": _make_node("f", "f"),
+        }
+        edges = [
+            CodeEdge(
+                source_id="mod",
+                target_id="f",
+                kind=EdgeKind.CONTAINS,
+            ),
+        ]
+        graph = CodeGraph(nodes=nodes, edges=edges)
+        store = GraphStore(graph)
+        assert store.callees_of("mod") == []
+
+    def test_callers_only_calls_edges(self) -> None:
+        """Only CALLS edges should count for callers."""
+        nodes = {
+            "mod": _make_node("mod", "mod"),
+            "f": _make_node("f", "f"),
+        }
+        edges = [
+            CodeEdge(
+                source_id="mod",
+                target_id="f",
+                kind=EdgeKind.CONTAINS,
+            ),
+        ]
+        graph = CodeGraph(nodes=nodes, edges=edges)
+        store = GraphStore(graph)
+        assert store.callers_of("f") == []
+
+
+class TestGraphStorePaths:
+    def test_paths_a_to_c(self) -> None:
+        _, store = _build_graph()
+        paths = store.paths_between("a", "c")
+        assert len(paths) == 1
+        assert paths[0] == ["a", "b", "c"]
+
+    def test_paths_a_to_d(self) -> None:
+        _, store = _build_graph()
+        paths = store.paths_between("a", "d")
+        assert len(paths) == 1
+        assert paths[0] == ["a", "d"]
+
+    def test_no_path(self) -> None:
+        _, store = _build_graph()
+        assert store.paths_between("c", "a") == []
+
+    def test_paths_nonexistent_src(self) -> None:
+        _, store = _build_graph()
+        assert store.paths_between("zzz", "c") == []
+
+    def test_paths_nonexistent_dst(self) -> None:
+        _, store = _build_graph()
+        assert store.paths_between("a", "zzz") == []
+
+    def test_paths_both_nonexistent(self) -> None:
+        _, store = _build_graph()
+        assert store.paths_between("zzz", "yyy") == []
+
+    def test_paths_max_depth_too_short(self) -> None:
+        _, store = _build_graph()
+        paths = store.paths_between("a", "c", max_depth=1)
+        assert len(paths) == 0
+
+    def test_paths_max_depth_sufficient(self) -> None:
+        """max_depth=3 should find path a->b->c (2 edges)."""
+        _, store = _build_graph()
+        paths = store.paths_between("a", "c", max_depth=3)
+        assert len(paths) == 1
+        assert paths[0] == ["a", "b", "c"]
+
+    def test_paths_default_max_depth(self) -> None:
+        """Default max_depth=20 should find all paths."""
+        _, store = _build_graph()
+        paths = store.paths_between("a", "c")
+        assert len(paths) == 1
+
+    def test_paths_default_max_depth_is_20(self) -> None:
+        """Verify the default cutoff is exactly 20."""
+        import inspect
+
+        sig = inspect.signature(GraphStore.paths_between)
+        assert sig.parameters["max_depth"].default == 20
+
+    def test_paths_direct(self) -> None:
+        _, store = _build_graph()
+        paths = store.paths_between("a", "b")
+        assert len(paths) == 1
+        assert paths[0] == ["a", "b"]
+
+    def test_paths_self(self) -> None:
+        """Path from node to itself has no simple path."""
+        _, store = _build_graph()
+        paths = store.paths_between("a", "a")
+        assert len(paths) == 0
+
+    def test_paths_ignore_non_call_edges(self) -> None:
+        """Structural edges must not create call paths."""
+        _, store = _build_contains_bridge_graph()
+        assert store.paths_between("mod", "b") == []
+        assert store.paths_between("a", "b") == [["a", "b"]]
+
+
+class TestGraphStoreReachability:
+    def test_reachable_from_a(self) -> None:
+        _, store = _build_graph()
+        reachable = store.reachable_from("a")
+        assert reachable == {"b", "c", "d"}
+
+    def test_reachable_from_b(self) -> None:
+        _, store = _build_graph()
+        reachable = store.reachable_from("b")
+        assert reachable == {"c"}
+
+    def test_reachable_from_leaf(self) -> None:
+        _, store = _build_graph()
+        assert store.reachable_from("c") == set()
+
+    def test_reachable_from_d(self) -> None:
+        _, store = _build_graph()
+        assert store.reachable_from("d") == set()
+
+    def test_reachable_from_nonexistent(self) -> None:
+        _, store = _build_graph()
+        assert store.reachable_from("zzz") == set()
+
+    def test_reachable_ignores_non_call_edges(self) -> None:
+        _, store = _build_contains_bridge_graph()
+        assert store.reachable_from("mod") == set()
+        assert store.reachable_from("a") == {"b"}
+
+
+class TestGraphStoreAncestors:
+    def test_ancestors_ignore_non_call_edges(self) -> None:
+        _, store = _build_contains_bridge_graph()
+        assert store.ancestors_of("b") == {"a"}
+        assert store.ancestors_of("a") == set()
+
+
+class TestGraphStoreAnnotations:
+    def test_nodes_with_annotation(self) -> None:
+        graph, _ = _build_graph()
+        graph.annotations["b"] = [
+            Annotation(
+                kind=AnnotationKind.ASSUMPTION,
+                description="x > 0",
+                source="docstring",
+            ),
+        ]
+        store = GraphStore(graph)
+        nodes = store.nodes_with_annotation(AnnotationKind.ASSUMPTION)
+        assert len(nodes) == 1
+        assert nodes[0].id == "b"
+
+    def test_no_matching_annotations(self) -> None:
+        _, store = _build_graph()
+        nodes = store.nodes_with_annotation(AnnotationKind.ASSUMPTION)
+        assert len(nodes) == 0
+
+    def test_annotation_wrong_kind(self) -> None:
+        """Querying for a different kind should find nothing."""
+        graph, _ = _build_graph()
+        graph.annotations["a"] = [
+            Annotation(
+                kind=AnnotationKind.ASSUMPTION,
+                description="test",
+                source="test",
+            ),
+        ]
+        store = GraphStore(graph)
+        nodes = store.nodes_with_annotation(AnnotationKind.INVARIANT)
+        assert len(nodes) == 0
+
+
+class TestGraphStoreEntrypoints:
+    def test_all_entrypoints(self) -> None:
+        graph, _ = _build_graph()
+        graph.entrypoints["a"] = EntrypointTag(
+            kind=EntrypointKind.USER_INPUT,
+            trust_level=TrustLevel.UNTRUSTED_EXTERNAL,
+        )
+        store = GraphStore(graph)
+        eps = store.all_entrypoints()
+        assert len(eps) == 1
+        assert eps[0][0] == "a"
+        assert eps[0][1].kind == EntrypointKind.USER_INPUT
+        assert eps[0][1].trust_level == TrustLevel.UNTRUSTED_EXTERNAL
+
+    def test_all_entrypoints_empty(self) -> None:
+        _, store = _build_graph()
+        assert store.all_entrypoints() == []
+
+    def test_entrypoint_paths_to(self) -> None:
+        graph, _ = _build_graph()
+        graph.entrypoints["a"] = EntrypointTag(
+            kind=EntrypointKind.API,
+        )
+        store = GraphStore(graph)
+        paths = store.entrypoint_paths_to("c")
+        assert len(paths) == 1
+        assert paths[0] == ["a", "b", "c"]
+
+    def test_entrypoint_paths_to_direct(self) -> None:
+        graph, _ = _build_graph()
+        graph.entrypoints["a"] = EntrypointTag(
+            kind=EntrypointKind.API,
+        )
+        store = GraphStore(graph)
+        paths = store.entrypoint_paths_to("b")
+        assert len(paths) == 1
+        assert paths[0] == ["a", "b"]
+
+    def test_entrypoint_paths_to_unreachable(self) -> None:
+        """If entrypoint can't reach target, no paths returned."""
+        graph, _ = _build_graph()
+        graph.entrypoints["c"] = EntrypointTag(
+            kind=EntrypointKind.API,
+        )
+        store = GraphStore(graph)
+        paths = store.entrypoint_paths_to("a")
+        assert paths == []
+
+    def test_entrypoint_paths_to_self(self) -> None:
+        graph, _ = _build_graph()
+        graph.entrypoints["a"] = EntrypointTag(
+            kind=EntrypointKind.API,
+        )
+        store = GraphStore(graph)
+        paths = store.entrypoint_paths_to("a")
+        assert paths == []
+
+    def test_entrypoint_paths_max_depth(self) -> None:
+        graph, _ = _build_graph()
+        graph.entrypoints["a"] = EntrypointTag(
+            kind=EntrypointKind.API,
+        )
+        store = GraphStore(graph)
+        # max_depth=1 should not find a->b->c (depth 2)
+        paths = store.entrypoint_paths_to("c", max_depth=1)
+        assert paths == []
+
+    def test_entrypoint_paths_default_max_depth_is_20(self) -> None:
+        """Verify the default cutoff is exactly 20."""
+        import inspect
+
+        sig = inspect.signature(GraphStore.entrypoint_paths_to)
+        assert sig.parameters["max_depth"].default == 20
+
+    def test_multiple_entrypoints(self) -> None:
+        """Multiple entrypoints can produce paths to same target."""
+        graph, _ = _build_graph()
+        graph.entrypoints["a"] = EntrypointTag(
+            kind=EntrypointKind.API,
+        )
+        graph.entrypoints["b"] = EntrypointTag(
+            kind=EntrypointKind.USER_INPUT,
+        )
+        store = GraphStore(graph)
+        paths = store.entrypoint_paths_to("c")
+        assert len(paths) == 2
+        path_strs = [tuple(p) for p in paths]
+        assert ("a", "b", "c") in path_strs
+        assert ("b", "c") in path_strs
+
+    def test_entrypoint_paths_ignore_non_call_edges(self) -> None:
+        graph, _ = _build_contains_bridge_graph()
+        graph.entrypoints["mod"] = EntrypointTag(kind=EntrypointKind.API)
+        store = GraphStore(graph)
+        assert store.entrypoint_paths_to("b") == []
+
+
+class TestGraphStoreComplexity:
+    def test_nodes_by_complexity(self) -> None:
+        graph, _ = _build_graph()
+        graph.nodes["a"] = CodeUnit(
+            id="a",
+            name="a",
+            kind=NodeKind.FUNCTION,
+            location=_LOC,
+            cyclomatic_complexity=15,
+        )
+        graph.nodes["b"] = CodeUnit(
+            id="b",
+            name="b",
+            kind=NodeKind.FUNCTION,
+            location=_LOC,
+            cyclomatic_complexity=3,
+        )
+        store = GraphStore(graph)
+        hot = store.nodes_by_complexity(10)
+        assert len(hot) == 1
+        assert hot[0].id == "a"
+        assert hot[0].cyclomatic_complexity == 15
+
+    def test_boundary_complexity(self) -> None:
+        graph, _ = _build_graph()
+        graph.nodes["a"] = CodeUnit(
+            id="a",
+            name="a",
+            kind=NodeKind.FUNCTION,
+            location=_LOC,
+            cyclomatic_complexity=10,
+        )
+        store = GraphStore(graph)
+        # Exactly at threshold should be included (>=)
+        assert len(store.nodes_by_complexity(10)) == 1
+        # One above threshold should exclude
+        assert len(store.nodes_by_complexity(11)) == 0
+
+    def test_none_complexity_excluded(self) -> None:
+        """Nodes with None complexity should be excluded."""
+        graph, _ = _build_graph()
+        # Default nodes have None complexity
+        store = GraphStore(graph)
+        assert store.nodes_by_complexity(1) == []
+
+    def test_complexity_multiple_matches(self) -> None:
+        nodes = {
+            "a": _make_node("a", "a", complexity=10),
+            "b": _make_node("b", "b", complexity=20),
+            "c": _make_node("c", "c", complexity=5),
+        }
+        graph = CodeGraph(nodes=nodes, edges=[])
+        store = GraphStore(graph)
+        result = store.nodes_by_complexity(10)
+        ids = {n.id for n in result}
+        assert ids == {"a", "b"}
+
+
+class TestGraphStoreFindNode:
+    def test_find_by_exact_id(self) -> None:
+        _, store = _build_graph()
+        node = store.find_node("a")
+        assert node is not None
+        assert node.id == "a"
+        assert node.name == "a"
+
+    def test_find_by_name(self) -> None:
+        _, store = _build_graph()
+        node = store.find_node("b")
+        assert node is not None
+        assert node.id == "b"
+
+    def test_find_by_colon_suffix(self) -> None:
+        nodes = {"mod:func": _make_node("mod:func", "func")}
+        graph = CodeGraph(nodes=nodes, edges=[])
+        store = GraphStore(graph)
+        node = store.find_node("func")
+        assert node is not None
+        assert node.id == "mod:func"
+
+    def test_find_by_dot_method(self) -> None:
+        nodes = {
+            "mod:Cls.method": _make_node("mod:Cls.method", "method"),
+        }
+        graph = CodeGraph(nodes=nodes, edges=[])
+        store = GraphStore(graph)
+        node = store.find_node("method")
+        assert node is not None
+        assert node.id == "mod:Cls.method"
+
+    def test_find_prefers_exact_id(self) -> None:
+        """Exact ID match should win over name/suffix match."""
+        nodes = {
+            "a": _make_node("a", "different_name"),
+        }
+        graph = CodeGraph(nodes=nodes, edges=[])
+        store = GraphStore(graph)
+        node = store.find_node("a")
+        assert node is not None
+        assert node.id == "a"
+
+    def test_find_by_name_without_colon_suffix(self) -> None:
+        """Name match alone (no colon suffix) should still find the node."""
+        nodes = {"opaque_id": _make_node("opaque_id", "target")}
+        graph = CodeGraph(nodes=nodes, edges=[])
+        store = GraphStore(graph)
+        node = store.find_node("target")
+        assert node is not None
+        assert node.id == "opaque_id"
+
+    def test_find_node_returns_none(self) -> None:
+        _, store = _build_graph()
+        assert store.find_node("nonexistent") is None
+
+    def test_find_node_id(self) -> None:
+        _, store = _build_graph()
+        assert store.find_node_id("a") == "a"
+        assert store.find_node_id("nonexistent") is None
+
+    def test_find_node_id_colon_suffix(self) -> None:
+        nodes = {"mod:func": _make_node("mod:func", "func")}
+        graph = CodeGraph(nodes=nodes, edges=[])
+        store = GraphStore(graph)
+        assert store.find_node_id("func") == "mod:func"
+
+    def test_find_node_id_dot_method(self) -> None:
+        nodes = {
+            "mod:Cls.method": _make_node("mod:Cls.method", "method"),
+        }
+        graph = CodeGraph(nodes=nodes, edges=[])
+        store = GraphStore(graph)
+        assert store.find_node_id("method") == "mod:Cls.method"
+
+
+class TestGraphStoreAnnotationMutation:
+    def test_add_annotation_to_existing_node(self) -> None:
+        _, store = _build_graph()
+        ann = Annotation(
+            kind=AnnotationKind.ASSUMPTION,
+            description="x > 0",
+            source="llm",
+        )
+        assert store.add_annotation("a", ann) is True
+        assert len(store.annotations_for("a")) == 1
+        assert store.annotations_for("a")[0] == ann
+
+    def test_add_annotation_to_nonexistent_node(self) -> None:
+        _, store = _build_graph()
+        ann = Annotation(
+            kind=AnnotationKind.ASSUMPTION,
+            description="x > 0",
+            source="llm",
+        )
+        assert store.add_annotation("zzz", ann) is False
+
+    def test_annotations_for_with_data(self) -> None:
+        graph, _ = _build_graph()
+        graph.annotations["b"] = [
+            Annotation(
+                kind=AnnotationKind.PRECONDITION,
+                description="non-null",
+                source="docstring",
+            ),
+        ]
+        store = GraphStore(graph)
+        anns = store.annotations_for("b")
+        assert len(anns) == 1
+        assert anns[0].kind == AnnotationKind.PRECONDITION
+
+    def test_annotations_for_no_annotations(self) -> None:
+        _, store = _build_graph()
+        assert store.annotations_for("a") == []
+
+    def test_annotations_for_nonexistent_node(self) -> None:
+        _, store = _build_graph()
+        assert store.annotations_for("zzz") == []
+
+    def test_annotations_for_returns_copy(self) -> None:
+        _, store = _build_graph()
+        ann = Annotation(
+            kind=AnnotationKind.ASSUMPTION,
+            description="test",
+            source="test",
+        )
+        store.add_annotation("a", ann)
+        result = store.annotations_for("a")
+        result.clear()
+        assert len(store.annotations_for("a")) == 1
+
+    def test_clear_annotations_existing_node(self) -> None:
+        _, store = _build_graph()
+        ann = Annotation(
+            kind=AnnotationKind.ASSUMPTION,
+            description="test",
+            source="test",
+        )
+        store.add_annotation("a", ann)
+        assert store.clear_annotations("a") is True
+        assert store.annotations_for("a") == []
+
+    def test_clear_annotations_nonexistent_node(self) -> None:
+        _, store = _build_graph()
+        assert store.clear_annotations("zzz") is False
+
+    def test_clear_annotations_by_kind(self) -> None:
+        _, store = _build_graph()
+        store.add_annotation(
+            "a",
+            Annotation(
+                kind=AnnotationKind.ASSUMPTION,
+                description="assume",
+                source="test",
+            ),
+        )
+        store.add_annotation(
+            "a",
+            Annotation(
+                kind=AnnotationKind.INVARIANT,
+                description="invariant",
+                source="test",
+            ),
+        )
+        assert store.clear_annotations("a", AnnotationKind.ASSUMPTION) is True
+        anns = store.annotations_for("a")
+        assert len(anns) == 1
+        assert anns[0].kind == AnnotationKind.INVARIANT


### PR DESCRIPTION
`reachable_from`, `ancestors_of`, `paths_between` and entrypoint path queries were traversing every edge in the graph. Structural edges like `CONTAINS` would thus show up as call reachability.

This changes transitive traversal to use a call-only graph and updates blast-radius preanalysis to use the same call-only view.

Let me know if the test changes aren't needed, great project btw. I intend to contribute something substantial in future.

**AI Disclosure:** This code was written with ChatGPT 5.5 (Codex) and the changes were reviewed by ChatGPT 5.5 (Codex) & Gemini 3.1 Pro (Jules).