### PR TITLE
restrict transitive traversal to call edges

### DIFF
--- a/src/trailmark/analysis/preanalysis.py
+++ b/src/trailmark/analysis/preanalysis.py
@@ -78,9 +78,9 @@ def _compute_blast_radius(store: GraphStore) -> dict[str, Any]:
     Nodes above the threshold are collected in a subgraph.
     """
     graph = store._graph  # noqa: SLF001
-    digraph = store._digraph  # noqa: SLF001
-    id_to_idx = store._id_to_idx  # noqa: SLF001
-    idx_to_id = store._idx_to_id  # noqa: SLF001
+    digraph = store._call_digraph  # noqa: SLF001
+    id_to_idx = store._call_id_to_idx  # noqa: SLF001
+    idx_to_id = store._call_idx_to_id  # noqa: SLF001
 
     high_blast: set[str] = set()
     max_radius = 0

--- a/src/trailmark/storage/graph_store.py
+++ b/src/trailmark/storage/graph_store.py
@@ -20,25 +20,39 @@ class GraphStore:
     def __init__(self, graph: CodeGraph) -> None:
         self._graph = graph
         self._digraph: rx.PyDiGraph[str, CodeEdge] = rx.PyDiGraph()
+        self._call_digraph: rx.PyDiGraph[str, CodeEdge] = rx.PyDiGraph()
         self._id_to_idx: dict[str, int] = {}
         self._idx_to_id: dict[int, str] = {}
+        self._call_id_to_idx: dict[str, int] = {}
+        self._call_idx_to_id: dict[int, str] = {}
         self._build_index()
 
     def _build_index(self) -> None:
         """Populate the rustworkx digraph from the CodeGraph."""
         for node_id in self._graph.nodes:
             idx = self._digraph.add_node(node_id)
+            call_idx = self._call_digraph.add_node(node_id)
             self._id_to_idx[node_id] = idx
             self._idx_to_id[idx] = node_id
+            self._call_id_to_idx[node_id] = call_idx
+            self._call_idx_to_id[call_idx] = node_id
 
         for edge in self._graph.edges:
             src_idx = self._id_to_idx.get(edge.source_id)
             tgt_idx = self._id_to_idx.get(edge.target_id)
             if src_idx is not None and tgt_idx is not None:
                 self._digraph.add_edge(src_idx, tgt_idx, edge)
+            if edge.kind == EdgeKind.CALLS:
+                call_src_idx = self._call_id_to_idx.get(edge.source_id)
+                call_tgt_idx = self._call_id_to_idx.get(edge.target_id)
+                if call_src_idx is not None and call_tgt_idx is not None:
+                    self._call_digraph.add_edge(call_src_idx, call_tgt_idx, edge)
 
     def _idx(self, node_id: str) -> int | None:
         return self._id_to_idx.get(node_id)
+
+    def _call_idx(self, node_id: str) -> int | None:
+        return self._call_id_to_idx.get(node_id)
 
     def _node(self, node_id: str) -> CodeUnit | None:
         return self._graph.nodes.get(node_id)
@@ -102,25 +116,25 @@ class GraphStore:
         max_depth: int = 20,
     ) -> list[list[str]]:
         """Find all simple paths between two nodes (up to max_depth)."""
-        src_idx = self._idx(src_id)
-        dst_idx = self._idx(dst_id)
+        src_idx = self._call_idx(src_id)
+        dst_idx = self._call_idx(dst_id)
         if src_idx is None or dst_idx is None:
             return []
         raw_paths: list[list[int]] = rx.digraph_all_simple_paths(
-            self._digraph,
+            self._call_digraph,
             src_idx,
             dst_idx,
             cutoff=max_depth,
         )
-        return [[self._idx_to_id[i] for i in path] for path in raw_paths]
+        return [[self._call_idx_to_id[i] for i in path] for path in raw_paths]
 
     def reachable_from(self, node_id: str) -> set[str]:
         """Return all node IDs reachable from the given node."""
-        idx = self._idx(node_id)
+        idx = self._call_idx(node_id)
         if idx is None:
             return set()
-        descendants = rx.descendants(self._digraph, idx)
-        return {self._idx_to_id[i] for i in descendants}
+        descendants = rx.descendants(self._call_digraph, idx)
+        return {self._call_idx_to_id[i] for i in descendants}
 
     def nodes_with_annotation(
         self,
@@ -234,8 +248,8 @@ class GraphStore:
 
     def ancestors_of(self, node_id: str) -> set[str]:
         """Return all node IDs that can reach the given node."""
-        idx = self._idx(node_id)
+        idx = self._call_idx(node_id)
         if idx is None:
             return set()
-        ancestor_indices = rx.ancestors(self._digraph, idx)
-        return {self._idx_to_id[i] for i in ancestor_indices}
+        ancestor_indices = rx.ancestors(self._call_digraph, idx)
+        return {self._call_idx_to_id[i] for i in ancestor_indices}

--- a/tests/test_hidden_apis.py
+++ b/tests/test_hidden_apis.py
@@ -36,15 +36,11 @@ class TestAncestorsOf:
         engine = QueryEngine.from_directory(str(tmp_path))
         assert engine.ancestors_of("does_not_exist") == []
 
-    def test_node_with_no_callers_has_only_module_ancestor(self, tmp_path: Path) -> None:
-        """A function with no callers still has the module as an ancestor
-        via the `contains` edge. Function-level ancestors should be empty.
-        """
+    def test_node_with_no_callers_has_no_call_ancestors(self, tmp_path: Path) -> None:
+        """A function with no callers has no call ancestors."""
         (tmp_path / "app.py").write_text("def solo():\n    pass\n")
         engine = QueryEngine.from_directory(str(tmp_path))
-        ancestor_kinds = {a["kind"] for a in engine.ancestors_of("solo")}
-        assert "function" not in ancestor_kinds
-        assert "method" not in ancestor_kinds
+        assert engine.ancestors_of("solo") == []
 
 
 class TestReachableFrom:

--- a/tests/test_preanalysis.py
+++ b/tests/test_preanalysis.py
@@ -23,11 +23,12 @@ def _node(
     node_id: str,
     name: str,
     complexity: int | None = None,
+    kind: NodeKind = NodeKind.FUNCTION,
 ) -> CodeUnit:
     return CodeUnit(
         id=node_id,
         name=name,
-        kind=NodeKind.FUNCTION,
+        kind=kind,
         location=_LOC,
         cyclomatic_complexity=complexity,
     )
@@ -174,6 +175,22 @@ class TestBlastRadius:
         )
         # handler has CC=12, should appear as critical
         assert "handler" in anns[0]["description"]
+
+    def test_blast_radius_ignores_non_call_edges(self) -> None:
+        nodes = {
+            "mod": _node("mod", "mod", kind=NodeKind.MODULE),
+            "f": _node("f", "f", 7),
+        }
+        graph = CodeGraph(
+            nodes=nodes,
+            edges=[CodeEdge("mod", "f", EdgeKind.CONTAINS)],
+        )
+        engine = QueryEngine.from_graph(graph)
+        result = engine.preanalysis()
+
+        assert result["blast_radius"]["max_radius"] == 0
+        anns = engine.annotations_of("mod", kind=AnnotationKind.BLAST_RADIUS)
+        assert anns[0]["description"].startswith("0 downstream, 0 upstream")
 
 
 class TestEntrypointEnumeration:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -51,6 +51,21 @@ def _build_graph() -> tuple[CodeGraph, GraphStore]:
     return graph, GraphStore(graph)
 
 
+def _build_contains_bridge_graph() -> tuple[CodeGraph, GraphStore]:
+    """Build a graph where CONTAINS would be a false call bridge."""
+    nodes = {
+        "mod": _make_node("mod", "mod"),
+        "a": _make_node("a", "a"),
+        "b": _make_node("b", "b"),
+    }
+    edges = [
+        CodeEdge(source_id="mod", target_id="a", kind=EdgeKind.CONTAINS),
+        CodeEdge(source_id="a", target_id="b", kind=EdgeKind.CALLS),
+    ]
+    graph = CodeGraph(nodes=nodes, edges=edges)
+    return graph, GraphStore(graph)
+
+
 class TestGraphStoreCallers:
     def test_callers_of_b(self) -> None:
         _, store = _build_graph()
@@ -209,6 +224,12 @@ class TestGraphStorePaths:
         paths = store.paths_between("a", "a")
         assert len(paths) == 0
 
+    def test_paths_ignore_non_call_edges(self) -> None:
+        """Structural edges must not create call paths."""
+        _, store = _build_contains_bridge_graph()
+        assert store.paths_between("mod", "b") == []
+        assert store.paths_between("a", "b") == [["a", "b"]]
+
 
 class TestGraphStoreReachability:
     def test_reachable_from_a(self) -> None:
@@ -232,6 +253,18 @@ class TestGraphStoreReachability:
     def test_reachable_from_nonexistent(self) -> None:
         _, store = _build_graph()
         assert store.reachable_from("zzz") == set()
+
+    def test_reachable_ignores_non_call_edges(self) -> None:
+        _, store = _build_contains_bridge_graph()
+        assert store.reachable_from("mod") == set()
+        assert store.reachable_from("a") == {"b"}
+
+
+class TestGraphStoreAncestors:
+    def test_ancestors_ignore_non_call_edges(self) -> None:
+        _, store = _build_contains_bridge_graph()
+        assert store.ancestors_of("b") == {"a"}
+        assert store.ancestors_of("a") == set()
 
 
 class TestGraphStoreAnnotations:
@@ -358,6 +391,12 @@ class TestGraphStoreEntrypoints:
         path_strs = [tuple(p) for p in paths]
         assert ("a", "b", "c") in path_strs
         assert ("b", "c") in path_strs
+
+    def test_entrypoint_paths_ignore_non_call_edges(self) -> None:
+        graph, _ = _build_contains_bridge_graph()
+        graph.entrypoints["mod"] = EntrypointTag(kind=EntrypointKind.API)
+        store = GraphStore(graph)
+        assert store.entrypoint_paths_to("b") == []
 
 
 class TestGraphStoreComplexity:


### PR DESCRIPTION
`reachable_from`, `ancestors_of`, `paths_between` and entrypoint path queries were traversing every edge in the graph. Structural edges like CONTAINS would thus show up as call reachability.

This changes transitive traversal to use a call-only graph and updates blast-radius preanalysis to use the same call-only view.

Let me know if the test changes aren't needed, great project btw.

**AI Disclosure:** This code was written with ChatGPT 5.5 (Codex) and the changes were reviewed by ChatGPT 5.5 (Codex) & Gemini 3.1 Pro (Jules).