### PR TITLE
Exclude tree-sitter-language-pack 1.6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 dependencies = [
     "tree-sitter>=0.25,<1.0",
-    "tree-sitter-language-pack>=0.13,<2.0",
+    "tree-sitter-language-pack>=0.13,<2.0,!=1.6.3",
     "rustworkx>=0.17,<1.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ dev = [
 requires-dist = [
     { name = "rustworkx", specifier = ">=0.17,<1.0" },
     { name = "tree-sitter", specifier = ">=0.25,<1.0" },
-    { name = "tree-sitter-language-pack", specifier = ">=0.13,<2.0" },
+    { name = "tree-sitter-language-pack", specifier = ">=0.13,!=1.6.3,<2.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Exclude `tree-sitter-language-pack==1.6.3`, which does not publish a compatible CPython 3.12 macOS arm64 wheel.

This keeps Trailmark's dependency range compatible with the supported Python/macOS combination.

## Verification

```text
UV_EXCLUDE_NEWER=2026-04-17T00:53:06.94394Z uv lock --check --python /opt/homebrew/Caskroom/miniforge/base/envs/py312/bin/python
UV_EXCLUDE_NEWER=2026-04-17T00:53:06.94394Z uv run --python /opt/homebrew/Caskroom/miniforge/base/envs/py312/bin/python ruff check src tests
UV_EXCLUDE_NEWER=2026-04-17T00:53:06.94394Z uv run --python /opt/homebrew/Caskroom/miniforge/base/envs/py312/bin/python pytest -q
1038 passed
```