### PR TITLE
Recover C/C++ functions inside preprocessor blocks and error nodes

### DIFF
--- a/src/trailmark/parsers/c/parser.py
+++ b/src/trailmark/parsers/c/parser.py
@@ -92,6 +92,17 @@ def _visit_module(
         _visit_top_level_node(child, file_path, module_id, graph)
 
 
+_PREPROC_CONTAINER_TYPES = frozenset(
+    {
+        "preproc_if",
+        "preproc_ifdef",
+        "preproc_else",
+        "preproc_elif",
+        "ERROR",
+    }
+)
+
+
 def _visit_top_level_node(
     child: Node,
     file_path: str,
@@ -109,6 +120,9 @@ def _visit_top_level_node(
         _extract_struct(child, file_path, module_id, graph)
     elif child.type == "enum_specifier":
         _extract_enum(child, file_path, module_id, graph)
+    elif child.type in _PREPROC_CONTAINER_TYPES:
+        for nested in child.children:
+            _visit_top_level_node(nested, file_path, module_id, graph)
 
 
 def _extract_type_def(

--- a/src/trailmark/parsers/cpp/parser.py
+++ b/src/trailmark/parsers/cpp/parser.py
@@ -127,9 +127,14 @@ def _visit_top_level_node(
             module_id,
             graph,
         )
-    elif child.type == "linkage_specification":
-        # `extern "C" { ... }` wraps nested declarations — unwrap and
-        # dispatch each child back through this visitor.
+    elif child.type in (
+        "linkage_specification",
+        "preproc_if",
+        "preproc_ifdef",
+        "preproc_else",
+        "preproc_elif",
+        "ERROR",
+    ):
         for nested in child.children:
             _visit_top_level_node(nested, file_path, module_id, class_id, graph)
     elif child.type == "class_specifier":

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -192,6 +192,66 @@ class TestCParserDependencies:
         assert "myheader.h" in graph.dependencies
 
 
+PREPROC_GUARDED_CODE = """\
+void before_guard(void) {}
+
+#ifdef USE_FEATURE
+void feature_a(int x) {
+    x = x + 1;
+}
+#else
+void feature_b(int x) {
+    x = x - 1;
+}
+#endif
+
+void after_guard(void) {}
+"""
+
+PREPROC_SPLIT_SIGNATURE_CODE = """\
+void before_split(void) {}
+
+#if defined(_WIN32)
+unsigned int __stdcall thread_worker(void * arg)
+#else
+void * thread_worker(void * arg)
+#endif
+{
+    return 0;
+}
+
+void after_split(void) {
+    thread_worker(0);
+}
+"""
+
+
+class TestCParserPreprocessorRecovery:
+    def test_finds_functions_inside_ifdef_branches(self) -> None:
+        parser = CParser()
+        with tempfile.NamedTemporaryFile(suffix=".c", mode="w", delete=False) as f:
+            f.write(PREPROC_GUARDED_CODE)
+            f.flush()
+            graph = parser.parse_file(f.name)
+        os.unlink(f.name)
+        names = {n.name for n in graph.nodes.values() if n.kind == NodeKind.FUNCTION}
+        assert "before_guard" in names
+        assert "after_guard" in names
+        assert "feature_a" in names or "feature_b" in names
+
+    def test_finds_functions_after_split_signature(self) -> None:
+        """Functions after a #if/#else split signature are still extracted."""
+        parser = CParser()
+        with tempfile.NamedTemporaryFile(suffix=".c", mode="w", delete=False) as f:
+            f.write(PREPROC_SPLIT_SIGNATURE_CODE)
+            f.flush()
+            graph = parser.parse_file(f.name)
+        os.unlink(f.name)
+        names = {n.name for n in graph.nodes.values() if n.kind == NodeKind.FUNCTION}
+        assert "before_split" in names
+        assert "after_split" in names
+
+
 class TestCParseDirectory:
     def test_parses_multiple_files(self) -> None:
         parser = CParser()


### PR DESCRIPTION
## Summary

- Tree-sitter's C grammar places function definitions inside `preproc_if`, `preproc_ifdef`, `preproc_else`, `preproc_elif`, and `ERROR` container nodes rather than at the translation unit's top level
- The C and C++ parsers only walked `root.children`, silently missing all functions nested inside these containers
- The fix recurses into these container nodes in `_visit_top_level_node` for both parsers

## Why this happens

When tree-sitter encounters `#if`/`#else` blocks with alternative code paths (common in cross-platform C code), it nests all subsequent content inside the preprocessor node. For example:

```c
#if defined(_WIN32)
unsigned int __stdcall worker(void * arg)
#else
void * worker(void * arg)
#endif
{
    return 0;
}

// This function ends up inside the preproc_else node:
void important_api(int x) { ... }
```

Similarly, `#if`/`#elif`/`#else` chains inside static initializer arrays produce `ERROR` nodes that swallow all subsequent function definitions.

## Impact

Tested on [libavif](https://github.com/AOMediaCodec/libavif) v1.4.1 (24K lines of C):

| Metric | Before | After |
|---|---|---|
| Nodes | 818 | **1,015** (+197) |
| Functions | 680 | **798** (+118) |
| Call edges | 6,339 | **7,558** (+1,219) |

**118 functions across 14 files** were previously invisible. Key recoveries:

| File | Recovered | Notable functions |
|---|---|---|
| `src/reformat.c` | 12 | `avifImageYUVToRGB` (public YUV→RGB API, 9 cross-module callers) |
| `src/read.c` | 11 | `avifParseMinimizedImageBox` (cc=100, highest complexity on decode path) |
| `apps/shared/avifjpeg.c` | 24 | JPEG I/O with platform-specific code |
| `src/reformat_libyuv.c` | 18 | Entire libyuv integration (all functions behind `#ifdef`) |
| `src/codec_aom.c` | 14 | AOM codec interface |
| `src/obu.c` | 8 | AV1 bitstream parsing |

`avifParseMinimizedImageBox` at cc=100 is the new highest-complexity function on the decode path — it was entirely invisible before this fix because it sits inside `#if defined(AVIF_ENABLE_EXPERIMENTAL_MINI)`.

## Test plan

- [x] 2 new tests in `test_c_parser.py`: `#ifdef` branch recovery and `#if/#else` split-signature recovery
- [x] All 1,043 existing tests pass
- [x] Validated on real-world C codebase (libavif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)