### PR TITLE
fix: tree-sitter language pack compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 dependencies = [
     "tree-sitter>=0.25,<1.0",
-    "tree-sitter-language-pack>=0.13,<2.0,!=1.6.3",
+    "tree-sitter-language-pack>=0.13,<1.7,!=1.6.3",
     "rustworkx>=0.17,<1.0",
 ]
 

--- a/src/trailmark/parsers/erlang/parser.py
+++ b/src/trailmark/parsers/erlang/parser.py
@@ -405,11 +405,34 @@ def _walk_calls(
     calls: list[tuple[str, Node]],
 ) -> None:
     """Recursively find call nodes and extract targets."""
+    if node.type == "remote":
+        name = _remote_call_name(node)
+        if name:
+            calls.append((name, node))
+        _walk_call_arguments(node.child_by_field_name("fun"), calls)
+        return
+
     if node.type == "call":
         name = _call_target_name(node)
         if name:
             calls.append((name, node))
+        _walk_call_arguments(node, calls)
+        return
+
     for child in node.children:
+        _walk_calls(child, calls)
+
+
+def _walk_call_arguments(
+    node: Node | None,
+    calls: list[tuple[str, Node]],
+) -> None:
+    """Walk a call's argument expressions without re-visiting its target."""
+    if node is None:
+        return
+    for i, child in enumerate(node.children):
+        if node.field_name_for_child(i) == "expr":
+            continue
         _walk_calls(child, calls)
 
 
@@ -433,8 +456,8 @@ def _remote_call_name(remote: Node) -> str:
         return ""
     # remote_module has a module field containing the atom.
     mod_atom = mod_node.child_by_field_name("module")
-    mod_name = node_text(mod_atom) if mod_atom is not None else ""
-    fun_name = node_text(fun_node)
+    mod_name = node_text(mod_atom) if mod_atom is not None else node_text(mod_node).rstrip(":")
+    fun_name = _call_target_name(fun_node) if fun_node.type == "call" else node_text(fun_node)
     if mod_name and fun_name:
         return f"{mod_name}:{fun_name}"
     return ""

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,16 @@
+"""Regression tests for package dependency metadata."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_tree_sitter_language_pack_excludes_incompatible_1_8_series() -> None:
+    pyproject = tomllib.loads((Path(__file__).parents[1] / "pyproject.toml").read_text())
+    dependencies = pyproject["project"]["dependencies"]
+    dependency = next(dep for dep in dependencies if dep.startswith("tree-sitter-language-pack"))
+
+    assert "<1.7" in dependency
+    assert "<2.0" not in dependency
+    assert "!=1.6.3" in dependency

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ dev = [
 requires-dist = [
     { name = "rustworkx", specifier = ">=0.17,<1.0" },
     { name = "tree-sitter", specifier = ">=0.25,<1.0" },
-    { name = "tree-sitter-language-pack", specifier = ">=0.13,!=1.6.3,<2.0" },
+    { name = "tree-sitter-language-pack", specifier = ">=0.13,!=1.6.3,<1.7" },
 ]
 
 [package.metadata.requires-dev]
@@ -663,16 +663,16 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-language-pack"
-version = "1.6.0"
+version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tree-sitter" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/de/6e8d0b8b3883e034eb6e8de36745e3839e4cf0a080eaffcbb3cc2d3dc06e/tree_sitter_language_pack-1.6.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d9d2e394991eefb6dc5971ae95795654ba54a8ee3410585facab02525d60ccd3", size = 2247370, upload-time = "2026-04-14T09:25:53.17Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/c4/fc366dbf351a60c0be82040ac1d21c1c2c4dc0e9ee3890b1b67d9e8504c4/tree_sitter_language_pack-1.6.0-cp310-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:adf0a7529ce6aed91d05f89f38cd25ac605189500ad63d488bb1c88fddc26a02", size = 2425750, upload-time = "2026-04-14T09:25:55.373Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/38/e8d0acfff2bbc912ecdf24ae01985a2ec45e92685e72e4983ea52f2325e4/tree_sitter_language_pack-1.6.0-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:e05b73032e671465e8946b459eec3407fbacd59e214a643636f5919761eee417", size = 2561118, upload-time = "2026-04-14T09:25:57.455Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/18/9a8a24f54e472b21ab7a3f207b58569b8a7c83fdb24e7ce67c4914d5eac2/tree_sitter_language_pack-1.6.0-cp310-abi3-win_amd64.whl", hash = "sha256:a1222defc8ba8558f221e3d8319b5e1f97bd1b7f8320b6b1bbaf3d5591649af7", size = 2357768, upload-time = "2026-04-14T09:26:00.257Z" },
+    { url = "https://files.pythonhosted.org/packages/09/bd/ac34ab0ee92b2d27802754c575965e921490ce11b5357bf89f74a78e8309/tree_sitter_language_pack-1.6.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f5998cfee5735a8e7e691f577062ff7eb3a7ea405ae5654c9cecaa4a1e6c81b0", size = 2241997, upload-time = "2026-04-18T07:04:36.042Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e0/b997b8c3e0886288a47890e6313c3a7e74ea8192e2d141b3eab64d59a276/tree_sitter_language_pack-1.6.2-cp310-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8ce814ede4e295f3419ba179b523889c52cc3a998ac085356a470e776596c026", size = 2419565, upload-time = "2026-04-18T07:04:37.67Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a4/629e6983a93fbb52dc50af495ec0431565c6477eea4680d4298238e9831e/tree_sitter_language_pack-1.6.2-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2305df7835c1cb3d34b71450b79d135878bc25ea5d02d9984cee864607a4ad60", size = 2555465, upload-time = "2026-04-18T07:04:39.57Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9c/0f486ca7344f6f3345441e8516b464214c7c5a0f3775d11fda1368901c38/tree_sitter_language_pack-1.6.2-cp310-abi3-win_amd64.whl", hash = "sha256:08351222b43c3a73665571eaa440366add2093a2492bb35f032fb7a31945e720", size = 2351156, upload-time = "2026-04-18T07:04:41.377Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #40 by further constraining the maximum version range for this dependency.

We will tag v0.3.1 after this is merged.