### PR TITLE
chore: release v0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "trailmark"
-version = "0.3.0"
+version = "0.3.1"
 description = "Parse source code into a queryable graph of functions, classes, calls, and semantic annotations"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/trailmark/__init__.py
+++ b/src/trailmark/__init__.py
@@ -13,4 +13,4 @@ __all__ = [
     "parse_file",
     "supported_languages",
 ]
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/uv.lock
+++ b/uv.lock
@@ -599,7 +599,7 @@ wheels = [
 
 [[package]]
 name = "trailmark"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "rustworkx" },


### PR DESCRIPTION
(We protected the main branch, so this is necessary to update the version metadata before releasing.)