### PR TITLE
Bump tree-sitter-language-pack to >=1.8,<2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 dependencies = [
     "tree-sitter>=0.25,<1.0",
-    "tree-sitter-language-pack>=0.13,<1.7,!=1.6.3",
+    "tree-sitter-language-pack>=1.8,<2.0",
     "rustworkx>=0.17,<1.0",
 ]
 

--- a/src/trailmark/parsers/c/parser.py
+++ b/src/trailmark/parsers/c/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -59,7 +59,7 @@ class CParser:
         return "c"
 
     def __init__(self) -> None:
-        self._parser = get_parser("c")
+        self._parser = Parser(get_language("c"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single C file into a CodeGraph."""

--- a/src/trailmark/parsers/cairo/parser.py
+++ b/src/trailmark/parsers/cairo/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -48,7 +48,7 @@ class CairoParser:
         return "cairo"
 
     def __init__(self) -> None:
-        self._parser = get_parser("cairo")
+        self._parser = Parser(get_language("cairo"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single Cairo file into a CodeGraph."""

--- a/src/trailmark/parsers/cpp/parser.py
+++ b/src/trailmark/parsers/cpp/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -61,7 +61,7 @@ class CppParser:
         return "cpp"
 
     def __init__(self) -> None:
-        self._parser = get_parser("cpp")
+        self._parser = Parser(get_language("cpp"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single C++ file into a CodeGraph."""

--- a/src/trailmark/parsers/csharp/parser.py
+++ b/src/trailmark/parsers/csharp/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -63,9 +63,7 @@ class CSharpParser:
         return "csharp"
 
     def __init__(self) -> None:
-        # tree-sitter-language-pack 1.6.0's stub omits "csharp" from the
-        # SupportedLanguage Literal, but the runtime accepts it fine.
-        self._parser = get_parser("csharp")  # ty: ignore[invalid-argument-type]
+        self._parser = Parser(get_language("csharp"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single C# file into a CodeGraph."""

--- a/src/trailmark/parsers/dart/parser.py
+++ b/src/trailmark/parsers/dart/parser.py
@@ -25,8 +25,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -86,7 +86,7 @@ class DartParser:
         return "dart"
 
     def __init__(self) -> None:
-        self._parser = get_parser("dart")
+        self._parser = Parser(get_language("dart"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single .dart file into a CodeGraph."""

--- a/src/trailmark/parsers/erlang/parser.py
+++ b/src/trailmark/parsers/erlang/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -42,7 +42,7 @@ class ErlangParser:
         return "erlang"
 
     def __init__(self) -> None:
-        self._parser = get_parser("erlang")
+        self._parser = Parser(get_language("erlang"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single Erlang file into a CodeGraph."""

--- a/src/trailmark/parsers/go/parser.py
+++ b/src/trailmark/parsers/go/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -65,7 +65,7 @@ class GoParser:
         return "go"
 
     def __init__(self) -> None:
-        self._parser = get_parser("go")
+        self._parser = Parser(get_language("go"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single Go file into a CodeGraph."""

--- a/src/trailmark/parsers/haskell/parser.py
+++ b/src/trailmark/parsers/haskell/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -42,7 +42,7 @@ class HaskellParser:
         return "haskell"
 
     def __init__(self) -> None:
-        self._parser = get_parser("haskell")
+        self._parser = Parser(get_language("haskell"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single Haskell file into a CodeGraph."""

--- a/src/trailmark/parsers/java/parser.py
+++ b/src/trailmark/parsers/java/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -63,7 +63,7 @@ class JavaParser:
         return "java"
 
     def __init__(self) -> None:
-        self._parser = get_parser("java")
+        self._parser = Parser(get_language("java"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single Java file into a CodeGraph."""

--- a/src/trailmark/parsers/javascript/parser.py
+++ b/src/trailmark/parsers/javascript/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -57,7 +57,7 @@ class JavaScriptParser:
         return "javascript"
 
     def __init__(self) -> None:
-        self._parser = get_parser("javascript")
+        self._parser = Parser(get_language("javascript"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single JavaScript file into a CodeGraph."""

--- a/src/trailmark/parsers/kotlin/parser.py
+++ b/src/trailmark/parsers/kotlin/parser.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -81,7 +81,7 @@ class KotlinParser:
         return "kotlin"
 
     def __init__(self) -> None:
-        self._parser = get_parser("kotlin")
+        self._parser = Parser(get_language("kotlin"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single Kotlin file into a CodeGraph."""

--- a/src/trailmark/parsers/objc/parser.py
+++ b/src/trailmark/parsers/objc/parser.py
@@ -21,8 +21,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -69,7 +69,7 @@ class ObjCParser:
         return "objc"
 
     def __init__(self) -> None:
-        self._parser = get_parser("objc")
+        self._parser = Parser(get_language("objc"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single .m / .mm / .h file into a CodeGraph."""

--- a/src/trailmark/parsers/php/parser.py
+++ b/src/trailmark/parsers/php/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -61,7 +61,7 @@ class PHPParser:
         return "php"
 
     def __init__(self) -> None:
-        self._parser = get_parser("php")
+        self._parser = Parser(get_language("php"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single PHP file into a CodeGraph."""

--- a/src/trailmark/parsers/python/parser.py
+++ b/src/trailmark/parsers/python/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -54,7 +54,7 @@ class PythonParser:
         return "python"
 
     def __init__(self) -> None:
-        self._parser = get_parser("python")
+        self._parser = Parser(get_language("python"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single Python file into a CodeGraph."""

--- a/src/trailmark/parsers/ruby/parser.py
+++ b/src/trailmark/parsers/ruby/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -53,7 +53,7 @@ class RubyParser:
         return "ruby"
 
     def __init__(self) -> None:
-        self._parser = get_parser("ruby")
+        self._parser = Parser(get_language("ruby"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single Ruby file into a CodeGraph."""

--- a/src/trailmark/parsers/rust/parser.py
+++ b/src/trailmark/parsers/rust/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -62,7 +62,7 @@ class RustParser:
         return "rust"
 
     def __init__(self) -> None:
-        self._parser = get_parser("rust")
+        self._parser = Parser(get_language("rust"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single Rust file into a CodeGraph."""

--- a/src/trailmark/parsers/solidity/parser.py
+++ b/src/trailmark/parsers/solidity/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -62,7 +62,7 @@ class SolidityParser:
         return "solidity"
 
     def __init__(self) -> None:
-        self._parser = get_parser("solidity")
+        self._parser = Parser(get_language("solidity"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single Solidity file into a CodeGraph."""

--- a/src/trailmark/parsers/swift/parser.py
+++ b/src/trailmark/parsers/swift/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -78,7 +78,7 @@ class SwiftParser:
         return "swift"
 
     def __init__(self) -> None:
-        self._parser = get_parser("swift")
+        self._parser = Parser(get_language("swift"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single Swift file into a CodeGraph."""

--- a/src/trailmark/parsers/typescript/parser.py
+++ b/src/trailmark/parsers/typescript/parser.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tree_sitter import Node
-from tree_sitter_language_pack import get_parser
+from tree_sitter import Node, Parser
+from tree_sitter_language_pack import get_language
 
 from trailmark.models.edges import CodeEdge, EdgeConfidence, EdgeKind
 from trailmark.models.graph import CodeGraph
@@ -57,7 +57,7 @@ class TypeScriptParser:
         return "typescript"
 
     def __init__(self) -> None:
-        self._parser = get_parser("typescript")
+        self._parser = Parser(get_language("typescript"))
 
     def parse_file(self, file_path: str) -> CodeGraph:
         """Parse a single TypeScript file into a CodeGraph."""

--- a/tests/test_cairo_parser.py
+++ b/tests/test_cairo_parser.py
@@ -271,9 +271,10 @@ class TestCairoParserDependencies:
 class TestFirstPathSegment:
     def _parse_use(self, code: str) -> Node:
         """Parse a use declaration and return the scoped_identifier node."""
-        from tree_sitter_language_pack import get_parser
+        from tree_sitter import Parser
+        from tree_sitter_language_pack import get_language
 
-        p = get_parser("cairo")
+        p = Parser(get_language("cairo"))
         tree = p.parse(code.encode())
         # Navigate: program > cairo_1_file > use_declaration > scoped_identifier
         file_node = tree.root_node.children[0]
@@ -297,9 +298,10 @@ class TestFirstPathSegment:
 
     def test_returns_empty_for_no_identifier(self) -> None:
         """A synthetic node with no identifier children returns empty string."""
-        from tree_sitter_language_pack import get_parser
+        from tree_sitter import Parser
+        from tree_sitter_language_pack import get_language
 
-        p = get_parser("cairo")
+        p = Parser(get_language("cairo"))
         tree = p.parse(b"fn f() {}")
         # Use the function_definition node, which has no identifier
         # in the scoped_identifier sense - just pass a node that

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -6,11 +6,10 @@ import tomllib
 from pathlib import Path
 
 
-def test_tree_sitter_language_pack_excludes_incompatible_1_8_series() -> None:
+def test_tree_sitter_language_pack_pins_modern_series() -> None:
     pyproject = tomllib.loads((Path(__file__).parents[1] / "pyproject.toml").read_text())
     dependencies = pyproject["project"]["dependencies"]
     dependency = next(dep for dep in dependencies if dep.startswith("tree-sitter-language-pack"))
 
-    assert "<1.7" in dependency
-    assert "<2.0" not in dependency
-    assert "!=1.6.3" in dependency
+    assert ">=1.8" in dependency
+    assert "<2.0" in dependency

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-22T16:05:23.116517Z"
+exclude-newer = "2026-05-21T14:10:55.321277Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -620,7 +620,7 @@ dev = [
 requires-dist = [
     { name = "rustworkx", specifier = ">=0.17,<1.0" },
     { name = "tree-sitter", specifier = ">=0.25,<1.0" },
-    { name = "tree-sitter-language-pack", specifier = ">=0.13,!=1.6.3,<1.7" },
+    { name = "tree-sitter-language-pack", specifier = ">=1.8,<2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -663,16 +663,19 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-language-pack"
-version = "1.6.2"
+version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tree-sitter" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/f3/fc0eabffb192ce49abee47e0bb3fea70fecfeacc1b8159e6f069795d2294/tree_sitter_language_pack-1.8.1.tar.gz", hash = "sha256:800f8a92a2238e1b3abcc25cc86fd3a1b1d3392263c49266640c1b079a8e625e", size = 109775, upload-time = "2026-05-15T09:48:32.281Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/bd/ac34ab0ee92b2d27802754c575965e921490ce11b5357bf89f74a78e8309/tree_sitter_language_pack-1.6.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f5998cfee5735a8e7e691f577062ff7eb3a7ea405ae5654c9cecaa4a1e6c81b0", size = 2241997, upload-time = "2026-04-18T07:04:36.042Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/e0/b997b8c3e0886288a47890e6313c3a7e74ea8192e2d141b3eab64d59a276/tree_sitter_language_pack-1.6.2-cp310-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8ce814ede4e295f3419ba179b523889c52cc3a998ac085356a470e776596c026", size = 2419565, upload-time = "2026-04-18T07:04:37.67Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/a4/629e6983a93fbb52dc50af495ec0431565c6477eea4680d4298238e9831e/tree_sitter_language_pack-1.6.2-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2305df7835c1cb3d34b71450b79d135878bc25ea5d02d9984cee864607a4ad60", size = 2555465, upload-time = "2026-04-18T07:04:39.57Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/9c/0f486ca7344f6f3345441e8516b464214c7c5a0f3775d11fda1368901c38/tree_sitter_language_pack-1.6.2-cp310-abi3-win_amd64.whl", hash = "sha256:08351222b43c3a73665571eaa440366add2093a2492bb35f032fb7a31945e720", size = 2351156, upload-time = "2026-04-18T07:04:41.377Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/9c/a9faacacdec92026b88bceeb08646be7c32edf05796e6f19d00873cdc1e4/tree_sitter_language_pack-1.8.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b0e3cd56dc359dbd623cc90df09494be4de1605628e53f92b981cd78a7de1a81", size = 2083265, upload-time = "2026-05-15T09:48:19.532Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/44/aded4a03575c8b010b03d574fadb5dc705a898a1d940670014634b1d819e/tree_sitter_language_pack-1.8.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a5c378bf1b920fa2470a668a7bf20b2e99a9288641bf6a04c5cfb8051fe91ea1", size = 1943468, upload-time = "2026-05-15T09:48:21.788Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e4/732e445d4341e86473c082a9debbca7c46de17ac935284c7060202b068ba/tree_sitter_language_pack-1.8.1-cp310-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:fa15da867ca257353fa4a709fb6c10f2fcc4b8c0899f27b883872c2feeaac61e", size = 2085933, upload-time = "2026-05-15T09:48:24.02Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/20/6f0c5b2b40de5a38134a1810b718775b960170b841bd079bd85d8e5b6616/tree_sitter_language_pack-1.8.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:79c5a3ce9a912dfddd08147cc14c91f7baa152ca18d39591eb3db8471e42400d", size = 2197368, upload-time = "2026-05-15T09:48:25.957Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/35/c2a05ba39a65008a3c87dcf238ac3c164d349f504b1d8a03295dbdb5e6c7/tree_sitter_language_pack-1.8.1-cp310-abi3-win_amd64.whl", hash = "sha256:572a8c0b1528bd150366399f04deb9e8c8d30c5b5a3ee7dabca898c4eab22a9a", size = 1993818, upload-time = "2026-05-15T09:48:28.228Z" },
+    { url = "https://files.pythonhosted.org/packages/50/1b/6c59695ac025bded36d2a099c165cbb95c819b6cfa075229835cdb4211b7/tree_sitter_language_pack-1.8.1-cp310-abi3-win_arm64.whl", hash = "sha256:018d0a60eeb8de1aa79ac5ed1cba42643d93d4da140c77640ac1576b541e68b9", size = 1902157, upload-time = "2026-05-15T09:48:30.203Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `tree-sitter-language-pack` from `>=0.13,<1.7,!=1.6.3` to `>=1.8,<2.0`, dropping support for the older series outright.
- The 1.8 line ships its own `Parser` whose `parse()` takes `str` instead of `bytes`. Each language-pack-backed parser now constructs a canonical `tree_sitter.Parser` via `get_language(...)`, matching the pattern already used by the bundled `circom` and `masm` grammars.
- Drops the obsolete `# ty: ignore` workaround for the 1.6.0 `csharp` stub.
- Updates `tests/test_package_metadata.py` to assert the new pin; updates inline `get_parser` use in `tests/test_cairo_parser.py`.

Supersedes #44, which proposed accreting another version exclusion onto the constraint.

## Test plan
- [x] `uv run pytest -q` (1051 passed)
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ty check src/`
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)