### PR TITLE
feat(cli): expose diagram generation as `trailmark diagram` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,13 @@ trailmark entrypoints --json path/to/project
 trailmark diff before/ after/
 trailmark diff --repo . main HEAD          # compare git refs
 trailmark diff --json before/ after/        # machine-readable output
+
+# Generate a Mermaid diagram from the code graph. --type is required; the
+# choices are call-graph, class-hierarchy, module-deps, containment,
+# complexity, and data-flow. Use --focus to scope large graphs.
+trailmark diagram --target path/to/project --type call-graph
+trailmark diagram -t path/to/project -T call-graph -f parse_file --depth 3
+trailmark diagram -t path/to/project -T complexity --threshold 5 --direction LR
 ```
 
 ### Entrypoint detection

--- a/src/trailmark/cli.py
+++ b/src/trailmark/cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from trailmark import __version__
+from trailmark.diagram import add_diagram_arguments, build_engine, render_diagram
 from trailmark.query.api import QueryEngine
 
 _VERSION_STRING = f"trailmark {__version__}"
@@ -136,6 +137,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Output full augmented graph as JSON",
     )
 
+    diagram = subparsers.add_parser(
+        "diagram",
+        help="Generate a Mermaid diagram from the code graph",
+    )
+    add_diagram_arguments(diagram)
+
     return parser
 
 
@@ -158,6 +165,8 @@ def main() -> None:
         _run_entrypoints(args)
     elif args.command == "diff":
         _run_diff(args)
+    elif args.command == "diagram":
+        _run_diagram(args)
 
 
 def _run_analyze(args: argparse.Namespace) -> None:
@@ -219,6 +228,12 @@ def _run_augment(args: argparse.Namespace) -> None:
 
     if args.json:
         print(engine.to_json())
+
+
+def _run_diagram(args: argparse.Namespace) -> None:
+    """Execute the diagram subcommand."""
+    engine = build_engine(args.target, args.language)
+    print(render_diagram(engine, args))
 
 
 def _print_augment_result(

--- a/src/trailmark/diagram.py
+++ b/src/trailmark/diagram.py
@@ -462,12 +462,15 @@ def _warn_if_large(nodes: dict[str, Any]) -> None:
 # ── CLI entry point ──────────────────────────────────────────────
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    """Parse command-line arguments."""
-    p = argparse.ArgumentParser(description="Generate Mermaid diagrams from Trailmark graphs.")
-    p.add_argument("--target", "-t", required=True, help="Directory to analyze")
-    p.add_argument("--language", "-l", default="python", help="Source language")
-    p.add_argument(
+def add_diagram_arguments(parser: argparse.ArgumentParser) -> None:
+    """Register the diagram CLI options on a parser or subparser.
+
+    Shared by the standalone ``trailmark.diagram`` entry point and the
+    ``trailmark diagram`` subcommand so both expose an identical interface.
+    """
+    parser.add_argument("--target", "-t", required=True, help="Directory to analyze")
+    parser.add_argument("--language", "-l", default="python", help="Source language")
+    parser.add_argument(
         "--type",
         "-T",
         required=True,
@@ -475,45 +478,53 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         dest="diagram_type",
         help="Diagram type",
     )
-    p.add_argument("--focus", "-f", default=None, help="Focus node name")
-    p.add_argument("--depth", "-d", type=int, default=2, help="BFS depth")
-    p.add_argument(
+    parser.add_argument("--focus", "-f", default=None, help="Focus node name")
+    parser.add_argument("--depth", "-d", type=int, default=2, help="BFS depth")
+    parser.add_argument(
         "--direction",
         default="TB",
         choices=("TB", "LR"),
         help="Layout direction",
     )
-    p.add_argument(
+    parser.add_argument(
         "--threshold",
         type=int,
         default=10,
         help="Complexity threshold",
     )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    p = argparse.ArgumentParser(description="Generate Mermaid diagrams from Trailmark graphs.")
+    add_diagram_arguments(p)
     return p.parse_args(argv)
+
+
+def render_diagram(engine: QueryEngine, args: argparse.Namespace) -> str:
+    """Dispatch to the emitter for ``args.diagram_type`` and return Mermaid text.
+
+    ``args.diagram_type`` is constrained to ``_DIAGRAM_TYPES`` by argparse, so
+    the final branch handles ``containment`` without a fallback path.
+    """
+    if args.diagram_type == "call-graph":
+        return emit_call_graph(engine, args.focus, args.depth, args.direction)
+    if args.diagram_type == "complexity":
+        return emit_complexity(engine, args.threshold, args.direction)
+    if args.diagram_type == "data-flow":
+        return emit_data_flow(engine, args.focus, args.depth, args.direction)
+    if args.diagram_type == "class-hierarchy":
+        return emit_class_hierarchy(engine, args.direction)
+    if args.diagram_type == "module-deps":
+        return emit_module_deps(engine, args.direction)
+    return emit_containment(engine, args.direction)
 
 
 def main(argv: list[str] | None = None) -> int:
     """Entry point: parse args, build graph, emit diagram."""
     args = parse_args(argv)
     engine = build_engine(args.target, args.language)
-
-    if args.diagram_type == "call-graph":
-        result = emit_call_graph(engine, args.focus, args.depth, args.direction)
-    elif args.diagram_type == "complexity":
-        result = emit_complexity(engine, args.threshold, args.direction)
-    elif args.diagram_type == "data-flow":
-        result = emit_data_flow(engine, args.focus, args.depth, args.direction)
-    elif args.diagram_type == "class-hierarchy":
-        result = emit_class_hierarchy(engine, args.direction)
-    elif args.diagram_type == "module-deps":
-        result = emit_module_deps(engine, args.direction)
-    elif args.diagram_type == "containment":
-        result = emit_containment(engine, args.direction)
-    else:
-        print(f"Unknown type: {args.diagram_type}", file=sys.stderr)
-        return 1
-
-    print(result)
+    print(render_diagram(engine, args))
     return 0
 
 

--- a/tests/fixtures/kat/cli/no_command_help.expected.txt
+++ b/tests/fixtures/kat/cli/no_command_help.expected.txt
@@ -1,16 +1,17 @@
 usage: trailmark [-h] [--version]
-                 {version,analyze,diff,entrypoints,augment} ...
+                 {version,analyze,diff,entrypoints,augment,diagram} ...
 
 Parse source code into queryable graphs (v0.3.1)
 
 positional arguments:
-  {version,analyze,diff,entrypoints,augment}
+  {version,analyze,diff,entrypoints,augment,diagram}
     version             Print the Trailmark version and exit
     analyze             Analyze a directory and output the code graph
     diff                Structural diff between two code graphs
     entrypoints         List detected entrypoints and their trust
                         classification
     augment             Augment a code graph with SARIF or weAudit findings
+    diagram             Generate a Mermaid diagram from the code graph
 
 options:
   -h, --help            show this help message and exit

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -518,3 +518,61 @@ class TestAnalyzeCommand:
         assert "complexity=" in output
         with pytest.raises(json.JSONDecodeError):
             json.loads(output)
+
+
+class TestDiagramCommand:
+    """Exercise the `trailmark diagram` subcommand end-to-end."""
+
+    def _write_call_chain(self, tmp_path: Path) -> None:
+        sample = tmp_path / "app.py"
+        sample.write_text(
+            "def helper():\n    return 1\n\ndef main():\n    return helper()\n",
+        )
+
+    def test_call_graph_emits_flowchart(self, tmp_path: Path) -> None:
+        self._write_call_chain(tmp_path)
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["trailmark", "diagram", "-t", str(tmp_path), "-T", "call-graph"],
+            ),
+            patch("sys.stdout", new_callable=StringIO) as mock_out,
+        ):
+            main()
+        output = mock_out.getvalue()
+        assert output.startswith("flowchart TB")
+        assert "helper" in output
+
+    def test_direction_flag_changes_header(self, tmp_path: Path) -> None:
+        self._write_call_chain(tmp_path)
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "trailmark",
+                    "diagram",
+                    "-t",
+                    str(tmp_path),
+                    "-T",
+                    "call-graph",
+                    "--direction",
+                    "LR",
+                ],
+            ),
+            patch("sys.stdout", new_callable=StringIO) as mock_out,
+        ):
+            main()
+        assert mock_out.getvalue().startswith("flowchart LR")
+
+    def test_missing_type_exits(self, tmp_path: Path) -> None:
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["trailmark", "diagram", "-t", str(tmp_path)],
+            ),
+            pytest.raises(SystemExit),
+        ):
+            main()

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -231,6 +231,7 @@ class TestDiagramSubparser:
         assert action.required is True
         assert action.dest == "diagram_type"
         assert "-T" in action.option_strings
+        assert action.choices is not None
         assert "call-graph" in action.choices
 
     def test_language_default_python(
@@ -249,6 +250,7 @@ class TestDiagramSubparser:
     def test_direction_default_tb(self, subparsers_map: dict[str, argparse.ArgumentParser]) -> None:
         action = _option(subparsers_map["diagram"], "--direction")
         assert action.default == "TB"
+        assert action.choices is not None
         assert set(action.choices) == {"TB", "LR"}
 
 

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -63,6 +63,7 @@ class TestTopLevelParser:
             "augment",
             "entrypoints",
             "diff",
+            "diagram",
             "version",
         }
 
@@ -215,6 +216,42 @@ class TestAugmentSubparser:
         assert action.default is False
 
 
+class TestDiagramSubparser:
+    def test_target_required_with_short_flag(
+        self, subparsers_map: dict[str, argparse.ArgumentParser]
+    ) -> None:
+        action = _option(subparsers_map["diagram"], "--target")
+        assert action.required is True
+        assert "-t" in action.option_strings
+
+    def test_type_required_with_choices(
+        self, subparsers_map: dict[str, argparse.ArgumentParser]
+    ) -> None:
+        action = _option(subparsers_map["diagram"], "--type")
+        assert action.required is True
+        assert action.dest == "diagram_type"
+        assert "-T" in action.option_strings
+        assert "call-graph" in action.choices
+
+    def test_language_default_python(
+        self, subparsers_map: dict[str, argparse.ArgumentParser]
+    ) -> None:
+        action = _option(subparsers_map["diagram"], "--language")
+        assert action.default == "python"
+
+    def test_depth_type_int_default_two(
+        self, subparsers_map: dict[str, argparse.ArgumentParser]
+    ) -> None:
+        action = _option(subparsers_map["diagram"], "--depth")
+        assert action.type is int
+        assert action.default == 2
+
+    def test_direction_default_tb(self, subparsers_map: dict[str, argparse.ArgumentParser]) -> None:
+        action = _option(subparsers_map["diagram"], "--direction")
+        assert action.default == "TB"
+        assert set(action.choices) == {"TB", "LR"}
+
+
 class TestParseBehavior:
     """End-to-end parse smoke tests that assert argparse produced the
     right Namespace fields for a representative command line."""
@@ -247,6 +284,19 @@ class TestParseBehavior:
     def test_augment_repeatable_sarif(self, parser: argparse.ArgumentParser) -> None:
         args = parser.parse_args(["augment", "p", "--sarif", "a.sarif", "--sarif", "b.sarif"])
         assert args.sarif == ["a.sarif", "b.sarif"]
+
+    def test_diagram_target_and_type(self, parser: argparse.ArgumentParser) -> None:
+        args = parser.parse_args(["diagram", "-t", "src/", "-T", "call-graph"])
+        assert args.command == "diagram"
+        assert args.target == "src/"
+        assert args.diagram_type == "call-graph"
+        assert args.language == "python"
+        assert args.direction == "TB"
+        assert args.depth == 2
+
+    def test_diagram_requires_type(self, parser: argparse.ArgumentParser) -> None:
+        with pytest.raises(SystemExit):
+            parser.parse_args(["diagram", "-t", "src/"])
 
 
 class TestVersionSubcommandExecution:


### PR DESCRIPTION
Closes #51.

## Problem

`src/trailmark/diagram.py` has a working `main()` CLI, but it was only reachable as a module (`python -m trailmark.diagram`) — it was never wired into the packaged `trailmark` entry point in `pyproject.toml`. The diagram skill had to invoke it as a standalone script.

## Change

Integrate the diagram CLI into the existing `trailmark` entry point as a `trailmark diagram` subcommand (the integration route the issue offered, rather than a second console script).

- **`diagram.py`**: extract `add_diagram_arguments()` and `render_diagram()` so the standalone entry point and the subcommand share one argument interface and one dispatch path; simplify `main()` to use them. The old runtime "unknown type" fallback is dropped since argparse `choices` already constrains `--type`.
- **`cli.py`**: register the `diagram` subparser and dispatch to it.
- **README**: document `trailmark diagram` (enforced by `test_readme.py`).
- **Tests**: regenerated the CLI help KAT snapshot; added parser-surface and end-to-end subcommand tests.

The standalone `python -m trailmark.diagram` path (used by the diagram skill's wrapper) still works unchanged.

## Interface note

`trailmark diagram` uses `--target/-t` and `--type/-T` rather than the positional `path` convention of `analyze`/`entrypoints`/`augment`. This preserves the pre-existing diagram CLI interface and its documented examples. Happy to switch to a positional `path` if matching the sibling subcommands is preferred.

## Verification

- `uv run ruff check` / `uv run ruff format --check` clean
- `uv run ty check` clean
- `uv run pytest -q` → 1148 passed
- Smoke-tested `trailmark diagram -t src/trailmark/query -T call-graph -f from_directory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)