### PR TITLE
chore: release v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "trailmark"
-version = "0.3.1"
+version = "0.4.0"
 description = "Parse source code into a queryable graph of functions, classes, calls, and semantic annotations"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/trailmark/__init__.py
+++ b/src/trailmark/__init__.py
@@ -13,4 +13,4 @@ __all__ = [
     "parse_file",
     "supported_languages",
 ]
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/tests/fixtures/kat/cli/no_command_help.expected.txt
+++ b/tests/fixtures/kat/cli/no_command_help.expected.txt
@@ -1,7 +1,7 @@
 usage: trailmark [-h] [--version]
                  {version,analyze,diff,entrypoints,augment,diagram} ...
 
-Parse source code into queryable graphs (v0.3.1)
+Parse source code into queryable graphs (<VERSION>)
 
 positional arguments:
   {version,analyze,diff,entrypoints,augment,diagram}

--- a/tests/test_kat_cli.py
+++ b/tests/test_kat_cli.py
@@ -24,7 +24,7 @@ FIXTURE_FILE = FIXTURE_DIR / "taxonomy.py"
 SNAPSHOT_DIR = Path(__file__).parent / "fixtures" / "kat" / "cli"
 UPDATE_ENV = "TRAILMARK_UPDATE_SNAPSHOTS"
 
-_VERSION_PATTERN = re.compile(r"\b\d+\.\d+\.\d+(?:[.\-+][\w.\-+]+)?\b")
+_VERSION_PATTERN = re.compile(r"\bv?\d+\.\d+\.\d+(?:[.\-+][\w.\-+]+)?\b")
 
 
 def _normalize(text: str) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-21T14:10:55.321277Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -599,7 +599,7 @@ wheels = [
 
 [[package]]
 name = "trailmark"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "rustworkx" },


### PR DESCRIPTION
## Release v0.4.0

Version bump and release-prep metadata for v0.4.0. No source-level changes — all features in this release already landed via #46–#53.

### Changes in this PR
- Bump version `0.3.1 → 0.4.0` in `pyproject.toml`, `src/trailmark/__init__.py`, and `uv.lock`.
- `uv.lock` also picks up the span-based (`P1W`) `exclude-newer` cooldown form (the prior frozen absolute timestamp is replaced by uv's sentinel; the 1-week cooldown span is unchanged).
- Fix `_VERSION_PATTERN` in `tests/test_kat_cli.py` to normalize `v`-prefixed versions (`\bv?\d+...`), so the `(vX.Y.Z)` string in the CLI help description is tokenized. The `no_command_help` snapshot now stores `<VERSION>` and no longer needs manual churn each release.

### What's new since v0.3.1 (already merged)
- **8 new language parsers:** Move, Tact, FunC, Sway, Rego, Protobuf, Thrift, GraphQL.
- **Proxy nodes** for unresolved call targets and resolvable type refs (`TYPE_USES` edges).
- **Generics** support (`TypeParameter`, `SPECIALIZES`/`RESOLVES_TO` edges, `generic_parameters()`/`type_references()` APIs).
- **Subgraph bridges** (`connect_subgraphs()`, `subgraph_edges()`).
- **Binary graph import** (`augment_binary`, `CORRESPONDS_TO` edges).
- **`trailmark diagram`** CLI subcommand.
- Storage refactor: per-edge-kind cached projections + public `rebuild_index()`.

### Verification
- `ruff check` clean
- `pytest`: 1166 passed
- `uv build`: produces `trailmark-0.4.0` sdist + wheel
- `uv sync`: lockfile fully resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)