### PR TITLE
Fix minor version of tree-sitter to 0.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { name = "Trail of Bits, Inc.", email = "opensource@trailofbits.com" },
 ]
 dependencies = [
-    "tree-sitter>=0.25,<1.0",
+    "tree-sitter~=0.25.0",
     "tree-sitter-language-pack>=1.8,<2.0",
     "rustworkx>=0.17,<1.0",
 ]


### PR DESCRIPTION
Seems like minor versions of `tree-sitter` can have breaking changes.

Currently, version 0.26.x breaks trailmark. We should fix the minor version, and upgrade it only after proper testing.